### PR TITLE
Add support for controlling the behaviour of document-proxy icons

### DIFF
--- a/modules/system/defaults/NSGlobalDomain.nix
+++ b/modules/system/defaults/NSGlobalDomain.nix
@@ -430,6 +430,15 @@ in {
       '';
     };
 
-  };
+    system.defaults.NSGlobalDomain.NSToolbarTitleViewRolloverDelay = mkOption {
+      type = types.nullOr types.float;
+      default = null;
+      description = ''
+        Toolbar title rollover delay.
+        Choose the delay of the auto-hidden document-proxy icon.
+        com.apple.universalaccess showWindowTitlebarIcons must be set to false.
+      '';
+    };
 
+  };
 }

--- a/modules/system/defaults/universalaccess.nix
+++ b/modules/system/defaults/universalaccess.nix
@@ -52,14 +52,13 @@ with lib;
       '';
     };
 
-    #system.defaults.universalaccess.showWindowTitlebarIcons = mkOption {
-    #  # Disabled because it requires sudo
-    #  # type = types.nullOr types.bool;
-    #  default = null;
-    #  description = ''
-    #    Always show folder icon before title in the title bar
-    #  '';
-    #};
+    system.defaults.universalaccess.showWindowTitlebarIcons = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Always show folder icon before title in the title bar
+      '';
+    };
 
   };
 }

--- a/modules/system/defaults/universalaccess.nix
+++ b/modules/system/defaults/universalaccess.nix
@@ -52,5 +52,14 @@ with lib;
       '';
     };
 
+    #system.defaults.universalaccess.showWindowTitlebarIcons = mkOption {
+    #  # Disabled because it requires sudo
+    #  # type = types.nullOr types.bool;
+    #  default = null;
+    #  description = ''
+    #    Always show folder icon before title in the title bar
+    #  '';
+    #};
+
   };
 }


### PR DESCRIPTION
Specifically this adds options for:

- `system.defaults.universalaccess.showWindowTitlebarIcons`
- `system.defaults.NSGlobalDomain.NSToolbarTitleViewRolloverDelay`

See https://macos-defaults.com/finder/nstoolbartitleviewrolloverdelay.html#toolbar-title-rollover-delay

~~Note: actually I had to disable `system.defaults.universalaccess.showWindowTitlebarIcons` as I couldn't get it to work.~~

I am pretty new to nix-darwin, and I can use guidance about this PR!