### PR TITLE
defaults: add `NSGlobalDomain.NSStatusItem{Spacing,SelectionPadding}`

### DIFF
--- a/modules/system/defaults/NSGlobalDomain.nix
+++ b/modules/system/defaults/NSGlobalDomain.nix
@@ -248,6 +248,24 @@ in {
       '';
     };
 
+    system.defaults.NSGlobalDomain.NSStatusItemSpacing = mkOption {
+      type = types.nullOr types.int;
+      default = null;
+      example = 12;
+      description = ''
+        Sets the spacing between status icons in the menu bar.
+      '';
+    };
+
+    system.defaults.NSGlobalDomain.NSStatusItemSelectionPadding = mkOption {
+      type = types.nullOr types.int;
+      default = null;
+      example = 6;
+      description = ''
+        Sets the padding around status icons in the menu bar.
+      '';
+    };
+
     system.defaults.NSGlobalDomain.InitialKeyRepeat = mkOption {
       type = types.nullOr types.int;
       default = null;


### PR DESCRIPTION
Add `NSStatusItemSpacing` and `NSStatusItemSelectionPadding` to `NSGlobalDomain` options.

These options control the spacing between and padding inside status icons in the menu bar. With these options, it's possible to squeeze more items on the menu bar, something that's especially useful on machines with a notch.

This is a copy of #872, which was closed without being merged.