### PR TITLE
homebrew: toggle analytics (off by default)

### DIFF
--- a/modules/homebrew.nix
+++ b/modules/homebrew.nix
@@ -136,7 +136,8 @@ let
 
     config = {
       brewBundleCmd = concatStringsSep " " (
-        optional (!config.autoUpdate) "HOMEBREW_NO_AUTO_UPDATE=1"
+        optional (cfg.global.noAnalytics) "HOMEBREW_NO_ANALYTICS=1"
+        ++ optional (!config.autoUpdate) "HOMEBREW_NO_AUTO_UPDATE=1"
         ++ [ "brew bundle --file='${brewfileFile}'" ]
         ++ optional (!config.upgrade) "--no-upgrade"
         ++ optional (config.cleanup == "uninstall") "--cleanup"
@@ -218,14 +219,22 @@ let
       # and error message with an assertion below if it's set by the user.
       noLock = mkOption { visible = false; default = null; };
 
+      noAnalytics = mkOption {
+        default = true;
+        example = false;
+        description = "Disable native Homebrew analytics";
+        type = types.bool;
+      };
+
       homebrewEnvironmentVariables = mkInternalOption { type = types.attrs; };
     };
 
     config = {
       homebrewEnvironmentVariables = {
         HOMEBREW_BUNDLE_FILE = mkIf config.brewfile "${brewfileFile}";
-        HOMEBREW_NO_AUTO_UPDATE = mkIf (!config.autoUpdate) "1";
         HOMEBREW_BUNDLE_NO_LOCK = mkIf (!config.lockfiles) "1";
+        HOMEBREW_NO_ANALYTICS = mkIf (config.noAnalytics) "1";
+        HOMEBREW_NO_AUTO_UPDATE = mkIf (!config.autoUpdate) "1";
       };
     };
   };

--- a/modules/homebrew.nix
+++ b/modules/homebrew.nix
@@ -219,7 +219,17 @@ let
       # and error message with an assertion below if it's set by the user.
       noLock = mkOption { visible = false; default = null; };
 
-      analytics = lib.mkEnableOption "Enable Homebrew analytics";
+      analytics = lib.mkEnableOption ''
+        Enable Homebrew analytics.
+
+        See "https://docs.brew.sh/Analytics".  Setting this to `false` (default)
+        will turn the analytics off.  Setting this to `true` will turn them on.
+
+        Implementation note: when disabled, this option sets the
+        `HOMEBREW_NO_ANALYTICS` environment variable, by adding it to
+        [](#opt-environment.variables).
+
+      '';
 
       homebrewEnvironmentVariables = mkInternalOption { type = types.attrs; };
     };

--- a/modules/homebrew.nix
+++ b/modules/homebrew.nix
@@ -136,7 +136,7 @@ let
 
     config = {
       brewBundleCmd = concatStringsSep " " (
-        optional (cfg.global.noAnalytics) "HOMEBREW_NO_ANALYTICS=1"
+        optional (!cfg.global.analytics) "HOMEBREW_NO_ANALYTICS=1"
         ++ optional (!config.autoUpdate) "HOMEBREW_NO_AUTO_UPDATE=1"
         ++ [ "brew bundle --file='${brewfileFile}'" ]
         ++ optional (!config.upgrade) "--no-upgrade"
@@ -219,12 +219,7 @@ let
       # and error message with an assertion below if it's set by the user.
       noLock = mkOption { visible = false; default = null; };
 
-      noAnalytics = mkOption {
-        default = true;
-        example = false;
-        description = "Disable native Homebrew analytics";
-        type = types.bool;
-      };
+      analytics = lib.mkEnableOption "Enable Homebrew analytics";
 
       homebrewEnvironmentVariables = mkInternalOption { type = types.attrs; };
     };
@@ -233,7 +228,7 @@ let
       homebrewEnvironmentVariables = {
         HOMEBREW_BUNDLE_FILE = mkIf config.brewfile "${brewfileFile}";
         HOMEBREW_BUNDLE_NO_LOCK = mkIf (!config.lockfiles) "1";
-        HOMEBREW_NO_ANALYTICS = mkIf (config.noAnalytics) "1";
+        HOMEBREW_NO_ANALYTICS = mkIf (!config.analytics) "1";
         HOMEBREW_NO_AUTO_UPDATE = mkIf (!config.autoUpdate) "1";
       };
     };

--- a/release.nix
+++ b/release.nix
@@ -82,7 +82,8 @@ in {
   tests.autossh = makeTest ./tests/autossh.nix;
   tests.environment-path = makeTest ./tests/environment-path.nix;
   tests.environment-terminfo = makeTest ./tests/environment-terminfo.nix;
-  tests.homebrew = makeTest ./tests/homebrew.nix;
+  tests.homebrew-brewfile = makeTest ./tests/homebrew-brewfile.nix;
+  tests.homebrew-config = makeTest ./tests/homebrew-config.nix;
   tests.launchd-daemons = makeTest ./tests/launchd-daemons.nix;
   tests.launchd-setenv = makeTest ./tests/launchd-setenv.nix;
   tests.networking-hostname = makeTest ./tests/networking-hostname.nix;

--- a/tests/homebrew-brewfile.nix
+++ b/tests/homebrew-brewfile.nix
@@ -1,3 +1,5 @@
+# Test the contents of the generated Brewfile
+
 { config, lib, ... }:
 
 let

--- a/tests/homebrew-config.nix
+++ b/tests/homebrew-config.nix
@@ -1,0 +1,15 @@
+# Test homebrew configuration on the system
+
+{ config, lib, ... }:
+
+{
+  homebrew.enable = true;
+
+  test = ''
+    echo 'checking Homebrew analytics' >&2
+    noanalytics=$(bash -c 'source ${config.system.build.setEnvironment}; echo $HOMEBREW_NO_ANALYTICS')
+    test "$noanalytics" = "1"
+    # This setting is also used when brew is invoked by the activation script
+    grep HOMEBREW_NO_ANALYTICS=1 ${config.out}/activate*
+  '';
+}


### PR DESCRIPTION
Is there an easy way to add "test groups" or somehow modularize tests? I wanted to add another test where the setting is explicitly toggled off but it would become a bit messy to have three separate homebrew tests top level