### PR TITLE
homebrew: allow setting greedy for all casks by default

### DIFF
--- a/modules/homebrew.nix
+++ b/modules/homebrew.nix
@@ -502,7 +502,9 @@ let
           [](#opt-homebrew.caskArgs) for the available options.
         '';
       };
-      greedy = mkNullOrBoolOption {
+      greedy = mkOption {
+        type = types.nullOr types.bool;
+        default = cfg.greedyCasks;
         description = ''
           Whether to always upgrade this cask regardless of whether it's unversioned or it updates
           itself.
@@ -628,6 +630,13 @@ in
       description = ''
         Arguments passed to {command}`brew install --cask` for all casks listed in
         [](#opt-homebrew.casks).
+      '';
+    };
+
+    greedyCasks = mkNullOrBoolOption {
+      description = ''
+        Whether to always upgrade casks listed in [](#opt-homebrew.casks) regardless
+        of whether it's unversioned or it updates itself.
       '';
     };
 


### PR DESCRIPTION
Specifying the `--greedy` flag with `brew upgrade` for each cask has to be done on an opt-in basis for each cask specified in `homebrew.casks`, which can be rather tedious.

This adds an option called `homebrew.greedyCasks` that sets the default value for the `homebrew.casks.*.greedy` option, so that all casks can be changed to be greedy at once, without needing to set that option for each cask. Opting out of `--greedy` by setting it to `false` per-cask when using this option is possible as well.

Closes #572, #1201.