### PR TITLE
services/netdata: add cacheDir option

### DIFF
--- a/modules/services/monitoring/netdata.nix
+++ b/modules/services/monitoring/netdata.nix
@@ -29,6 +29,12 @@ in {
         default = "/var/log/netdata";
         description = "Log directory for Netdata";
       };
+
+      cacheDir = mkOption {
+        type = types.path;
+        default = "/var/cache/netdata";
+        description = "Cache directory for Netdata";
+      };
     };
   };
 
@@ -50,6 +56,7 @@ in {
 
     system.activationScripts.preActivation.text = ''
       mkdir -p ${cfg.workDir}
+      mkdir -p ${cfg.cacheDir}
     '';
   };
 }


### PR DESCRIPTION
For me netdata could not start unless added cache directory:

```logs
time=2025-03-18T21:27:21.023+02:00 comm=netdata source=daemon level=info errno="2, No such file or directory" tid=257369  msg="CONFIG: cannot load cloud config '/var/lib/netdata/cloud.d/cloud.conf'. Running with internal defaults."
time=2025-03-18T21:27:21.024+02:00 comm=netdata source=daemon level=alert errno="2, No such file or directory" tid=257369  msg="Cannot create required directory '/var/cache/netdata'"
0   netdata                             0x0000000104845cb0 netdata_logger_fatal + 356
1   netdata                             0x00000001044d8734 verify_or_create_required_directory + 84
2   netdata                             0x00000001044d718c set_global_environment + 524
3   netdata                             0x00000001044db294 netdata_main + 1920
4   netdata                             0x00000001044dd178 main + 12
5   dyld                                0x0000000184394274 start + 2840
```