### PR TITLE
treewide: point to the new GitHub organization

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -209,7 +209,7 @@
 
     Use a channel for nix-darwin or configure nix.nixPath
 
-    sudo nix-channel --add https://github.com/LnL7/nix-darwin/archive/master.tar.gz darwin
+    sudo nix-channel --add https://github.com/nix-darwin/nix-darwin/archive/master.tar.gz darwin
     sudo nix-channel --update
 
     nix.nixPath =

--- a/README.md
+++ b/README.md
@@ -234,6 +234,6 @@ If you're adding a module, please add yourself to `meta.maintainers`, for exampl
 The `or` operator takes care of graceful degradation when `lib` from Nixpkgs
 goes out of sync.
 
-Also feel free to contact me if you have questions,
-- Matrix - @daiderd:matrix.org, you can find me in [#macos:nixos.org](https://matrix.to/#/#macos:nixos.org)
-- @LnL7 on twitter
+Feel free to contact us on Matrix if you have questions:
+* **User support:** [#macos:nixos.org](https://matrix.to/#/#macos:nixos.org)
+* **Development discussion:** [#nix-darwin-dev:nixos.org](https://matrix.to/#/#nix-darwin-dev:nixos.org)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[<img src="https://daiderd.com/nix-darwin/images/nix-darwin.png" width="200px" alt="logo" />](https://github.com/LnL7/nix-darwin)
+[<img src="https://nix-darwin.github.io/nix-darwin/images/nix-darwin.png" width="200px" alt="logo" />](https://github.com/nix-darwin/nix-darwin)
 
 # nix-darwin
 
-[![Test](https://github.com/LnL7/nix-darwin/actions/workflows/test.yml/badge.svg)](https://github.com/LnL7/nix-darwin/actions/workflows/test.yml)
+[![Test](https://github.com/nix-darwin/nix-darwin/actions/workflows/test.yml/badge.svg)](https://github.com/nix-darwin/nix-darwin/actions/workflows/test.yml)
 
 Nix modules for darwin, `/etc/nixos/configuration.nix` for macOS.
 
@@ -73,8 +73,8 @@ Add the following to `flake.nix` in the same folder as `configuration.nix`:
   inputs = {
     # Use `github:NixOS/nixpkgs/nixpkgs-24.11-darwin` to use Nixpkgs 24.11.
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    # Use `github:LnL7/nix-darwin/nix-darwin-24.11` to use Nixpkgs 24.11.
-    nix-darwin.url = "github:LnL7/nix-darwin/master";
+    # Use `github:nix-darwin/nix-darwin/nix-darwin-24.11` to use Nixpkgs 24.11.
+    nix-darwin.url = "github:nix-darwin/nix-darwin/master";
     nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
   };
 
@@ -142,9 +142,9 @@ Copy the [simple](./modules/examples/simple.nix) example to `/etc/nix-darwin/con
 
 ```bash
 # If you use Nixpkgs unstable (the default):
-sudo nix-channel --add https://github.com/LnL7/nix-darwin/archive/master.tar.gz darwin
+sudo nix-channel --add https://github.com/nix-darwin/nix-darwin/archive/master.tar.gz darwin
 # If you use Nixpkgs 24.11:
-sudo nix-channel --add https://github.com/LnL7/nix-darwin/archive/nix-darwin-24.11.tar.gz darwin
+sudo nix-channel --add https://github.com/nix-darwin/nix-darwin/archive/nix-darwin-24.11.tar.gz darwin
 
 sudo nix-channel --update
 ```
@@ -177,7 +177,7 @@ sudo nix-channel --update
 
 ## Documentation
 
-`darwin-help` will open up a local copy of the reference documentation, it can also be found online [here](https://daiderd.com/nix-darwin/manual/index.html).
+`darwin-help` will open up a local copy of the reference documentation, it can also be found online [here](https://nix-darwin.github.io/nix-darwin/manual/index.html).
 
 The documentation is also available as manpages by running `man 5 configuration.nix`.
 

--- a/doc/manual/default.nix
+++ b/doc/manual/default.nix
@@ -30,7 +30,7 @@ let
       declarations = map
         (decl:
           if lib.hasPrefix (toString prefix) (toString decl) then
-            gitHubDeclaration "LnL7" "nix-darwin" revision
+            gitHubDeclaration "nix-darwin" "nix-darwin" revision
               (lib.removePrefix "/"
                 (lib.removePrefix (toString prefix) (toString decl)))
           # TODO: handle this in a better way (may require upstream

--- a/eval-config.nix
+++ b/eval-config.nix
@@ -37,7 +37,7 @@ assert enableNixpkgsReleaseCheck -> checkRelease lib || throw ''
 
       inputs = {
         nixpkgs.url = "github:NixOS/nixpkgs/NIXPKGS-BRANCH";
-        nix-darwin.url = "github:LnL7/nix-darwin/NIX-DARWIN-BRANCH";
+        nix-darwin.url = "github:nix-darwin/nix-darwin/NIX-DARWIN-BRANCH";
         nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
         # …
       };
@@ -46,7 +46,7 @@ assert enableNixpkgsReleaseCheck -> checkRelease lib || throw ''
 
       $ sudo nix-channel --list
       nixpkgs https://nixos.org/channels/NIXPKGS-BRANCH
-      darwin https://github.com/LnL7/nix-darwin/archive/NIX-DARWIN-BRANCH.tar.gz
+      darwin https://github.com/nix-darwin/nix-darwin/archive/NIX-DARWIN-BRANCH.tar.gz
       …
       $ nix-channel --list
       …
@@ -58,12 +58,12 @@ assert enableNixpkgsReleaseCheck -> checkRelease lib || throw ''
   You can then fix your channels like this:
 
       $ sudo nix-channel --add https://nixos.org/channels/NIXPKGS-BRANCH nixpkgs
-      $ sudo nix-channel --add https://github.com/LnL7/nix-darwin/archive/NIX-DARWIN-BRANCH.tar.gz darwin
+      $ sudo nix-channel --add https://github.com/nix-darwin/nix-darwin/archive/NIX-DARWIN-BRANCH.tar.gz darwin
       $ sudo nix-channel --update
 
   After that, activating your system again should work correctly. If it
   doesn’t, please open an issue at
-  <https://github.com/LnL7/nix-darwin/issues/new> and include as much
+  <https://github.com/nix-darwin/nix-darwin/issues/new> and include as much
   information as possible.
 '';
 

--- a/modules/examples/flake/flake.nix
+++ b/modules/examples/flake/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    nix-darwin.url = "github:LnL7/nix-darwin/master";
+    nix-darwin.url = "github:nix-darwin/nix-darwin/master";
     nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
   };
 

--- a/modules/system/checks.nix
+++ b/modules/system/checks.nix
@@ -170,7 +170,7 @@ let
     if ! test -e "$darwinPath"; then
         echo "[1;31merror: Changed <darwin> but target does not exist, aborting activation[0m" >&2
         echo "Add the darwin repo as a channel or set nix.nixPath:" >&2
-        echo "$ sudo nix-channel --add https://github.com/LnL7/nix-darwin/archive/master.tar.gz darwin" >&2
+        echo "$ sudo nix-channel --add https://github.com/nix-darwin/nix-darwin/archive/master.tar.gz darwin" >&2
         echo "$ sudo nix-channel --update" >&2
         echo >&2
         echo "or set" >&2


### PR DESCRIPTION
To be merged after the [repository is moved](https://github.com/LnL7/nix-darwin/issues/1394).