### PR TITLE
networking: backport `domain`, `fqdn` and `fqdnOrHostName` options

### DIFF
--- a/modules/networking/default.nix
+++ b/modules/networking/default.nix
@@ -71,6 +71,55 @@ in
       '';
     };
 
+    networking.domain = mkOption {
+      default = null;
+      example = "home.arpa";
+      type = types.nullOr types.str;
+      description = ''
+        The domain.  It can be left empty if it is auto-detected through DHCP.
+      '';
+    };
+
+    networking.fqdn = mkOption {
+      readOnly = true;
+      type = types.str;
+      default =
+        if (cfg.hostName != "" && cfg.domain != null) then
+          "${cfg.hostName}.${cfg.domain}"
+        else
+          throw ''
+            The FQDN is required but cannot be determined. Please make sure that
+            both networking.hostName and networking.domain are set properly.
+          '';
+      defaultText = literalExpression ''"''${networking.hostName}.''${networking.domain}"'';
+      description = ''
+        The fully qualified domain name (FQDN) of this host. It is the result
+        of combining `networking.hostName` and `networking.domain.` Using this
+        option will result in an evaluation error if the hostname is empty or
+        no domain is specified.
+
+        Modules that accept a mere `networking.hostName` but prefer a fully qualified
+        domain name may use `networking.fqdnOrHostName` instead.
+      '';
+    };
+
+    networking.fqdnOrHostName = mkOption {
+      readOnly = true;
+      type = types.str;
+      default = if cfg.domain == null then cfg.hostName else cfg.fqdn;
+      defaultText = literalExpression ''
+        if cfg.domain == null then cfg.hostName else cfg.fqdn
+      '';
+      description = ''
+        Either the fully qualified domain name (FQDN), or just the host name if
+        it does not exists.
+
+        This is a convenience option for modules to read instead of `fqdn` when
+        a mere `hostName` is also an acceptable value; this option does not
+        throw an error when `domain` is unset.
+      '';
+    };
+
     networking.knownNetworkServices = mkOption {
       type = types.listOf types.str;
       default = [];

--- a/tests/networking-hostname.nix
+++ b/tests/networking-hostname.nix
@@ -1,4 +1,4 @@
-{ lib, config, pkgs, ... }:
+{ lib, config, ... }:
 
 {
   networking.hostName = "EVE";


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/blob/f675531bc7e6657c10a18b565cfebd8aa9e24c14/nixos/modules/tasks/network-interfaces.nix#L580-L618