### PR TITLE
networking.firewall: init module

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -45,6 +45,7 @@
   ./system/version.nix
   ./time
   ./networking
+  ./networking/firewall.nix
   ./nix
   ./nix/linux-builder.nix
   ./nix/nix-darwin.nix

--- a/modules/networking/firewall.nix
+++ b/modules/networking/firewall.nix
@@ -1,0 +1,87 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.networking.firewall;
+
+  onOff = cond: if cond then "on" else "off";
+
+  anchor = pkgs.writeText "nix" (
+    ''
+      #
+      # pf rules managed by nix-darwin
+      #
+
+    ''
+    + cfg.pf.rules
+  );
+in
+{
+  options = {
+    networking.firewall = {
+      enable = lib.mkOption {
+        type = lib.types.nullOr lib.types.bool;
+        default = null;
+        description = ''
+          Whether to enable Apple's built-in application firewall.
+
+          The default is null which lets macOS manage the firewall.
+        '';
+      };
+
+      stealthmode = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Whether to enable stealth mode.
+        '';
+      };
+
+      pf = {
+        enable = lib.mkEnableOption "packet filtering with pf";
+        rules = lib.mkOption {
+          default = "";
+          type = lib.types.lines;
+          description = ''
+            Packet filtering rules for {manpage}`pf(4)`.
+            See {manpage}`pf.conf(5)` for documentation.
+          '';
+        };
+      };
+    };
+  };
+
+  config = {
+    system.activationScripts.networking.text = lib.mkMerge [
+      (lib.mkIf (cfg.enable != null) ''
+        /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate ${onOff cfg.enable}
+        /usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode ${onOff cfg.stealthmode}
+      '')
+
+      (lib.mkIf (!cfg.pf.enable) ''
+        pfctl -a com.apple/nix -F all &> /dev/null
+
+        # Disable pf unless stealth mode is enabled (this is the default behavior in macOS).
+        if [ "$(/usr/libexec/ApplicationFirewall/socketfilterfw --getstealthmode)" == "Firewall stealth mode is off" ]; then
+          pfctl -d &> /dev/null
+        fi
+      '')
+    ];
+
+    launchd.daemons.pf = lib.mkIf cfg.pf.enable {
+      serviceConfig = {
+        ProgramArguments = [
+          "/bin/sh"
+          "-c"
+          "/bin/wait4path /nix/store &amp;&amp; exec /sbin/pfctl -e -a com.apple/nix -f ${anchor}"
+        ];
+
+        RunAtLoad = true;
+      };
+    };
+  };
+}

--- a/release.nix
+++ b/release.nix
@@ -85,6 +85,7 @@ in {
   tests.homebrew = makeTest ./tests/homebrew.nix;
   tests.launchd-daemons = makeTest ./tests/launchd-daemons.nix;
   tests.launchd-setenv = makeTest ./tests/launchd-setenv.nix;
+  tests.networking-firewall = makeTest ./tests/networking-firewall.nix;
   tests.networking-hostname = makeTest ./tests/networking-hostname.nix;
   tests.networking-networkservices = makeTest ./tests/networking-networkservices.nix;
   tests.nix-enable = makeTest ./tests/nix-enable.nix;

--- a/tests/networking-firewall.nix
+++ b/tests/networking-firewall.nix
@@ -1,0 +1,34 @@
+{ config, lib, ... }:
+
+{
+  networking.firewall.enable = true;
+  networking.firewall.stealthmode = true;
+  networking.firewall.pf.enable = true;
+  networking.firewall.pf.rules = ''
+    pass quick on lo0 no state
+  '';
+
+  test = ''
+    echo "checking firewall enablement in /activate" >&2
+    grep "/usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on" ${config.out}/activate
+    grep "/usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode on" ${config.out}/activate
+
+    echo "checking pf service in /Library/LaunchDaemons" >&2
+    /usr/bin/plutil -extract ProgramArguments raw -expect array \
+      ${config.out}/Library/LaunchDaemons/org.nixos.pf.plist | grep "3"
+    /usr/bin/plutil -extract ProgramArguments.0 raw -expect string \
+      ${config.out}/Library/LaunchDaemons/org.nixos.pf.plist | grep "/bin/sh"
+    /usr/bin/plutil -extract ProgramArguments.1 raw -expect string \
+      ${config.out}/Library/LaunchDaemons/org.nixos.pf.plist | grep "\-c"
+    /usr/bin/plutil -extract ProgramArguments.2 raw -expect string \
+      ${config.out}/Library/LaunchDaemons/org.nixos.pf.plist | grep \
+      "/bin/wait4path /nix/store && exec /sbin/pfctl -e -a com.apple/nix -f /nix/store/"
+    /usr/bin/plutil -extract RunAtLoad raw -expect bool \
+      ${config.out}/Library/LaunchDaemons/org.nixos.pf.plist | grep "true"
+
+    anchor=$(/usr/bin/plutil -extract ProgramArguments.2 raw -expect string \
+             ${config.out}/Library/LaunchDaemons/org.nixos.pf.plist | awk '{print $10}')
+    echo "checking pf rules in $anchor" >&2
+    grep "pass quick on lo0 no state" "$anchor"
+  '';
+}


### PR DESCRIPTION
Add a basic module to enable or disable the built-in macOS application firewall. The module also supports configuration of pf with custom rules (based on https://apple.stackexchange.com/a/429972).

Addresses: #1243