### PR TITLE
fix: allow path to be used for dock's persistent-apps

### DIFF
--- a/modules/system/defaults/dock.nix
+++ b/modules/system/defaults/dock.nix
@@ -155,7 +155,7 @@ in {
             };
 
         simpleType = types.either types.str types.path;
-        toTagged = path: { app = path; };
+        toTagged = path: { app = builtins.toString path; };
         in
       types.nullOr (types.listOf (types.coercedTo simpleType toTagged taggedType));
       default = null;


### PR DESCRIPTION
Fixes #1428

This use solution 1 in #1428.

