### PR TITLE
fix: NOT allow path to be used for dock's persistent-apps

### DIFF
--- a/modules/system/defaults/dock.nix
+++ b/modules/system/defaults/dock.nix
@@ -153,11 +153,9 @@ in {
                 };
               };
             };
-
-        simpleType = types.either types.str types.path;
         toTagged = path: { app = path; };
         in
-      types.nullOr (types.listOf (types.coercedTo simpleType toTagged taggedType));
+      types.nullOr (types.listOf (types.coercedTo types.str toTagged taggedType));
       default = null;
       example = [
         { app = "/Applications/Safari.app"; }


### PR DESCRIPTION
Fixes https://github.com/nix-darwin/nix-darwin/issues/1428

This use solution 2 in https://github.com/nix-darwin/nix-darwin/issues/1428.

Note that this may break configs that uses paths, which have not updated their `nix-darwin` since before commit https://github.com/nix-darwin/nix-darwin/commit/e21d07988b30adbd5b77d16f9fa40b7d5fc00a09.