### PR TITLE
feat: make persistent-others similar to the new persistent-apps

### DIFF
--- a/modules/system/defaults/dock.nix
+++ b/modules/system/defaults/dock.nix
@@ -197,16 +197,92 @@ in {
     };
 
     system.defaults.dock.persistent-others = mkOption {
-      type = types.nullOr (types.listOf (types.either types.path types.str));
+      type = let
+        folderType = types.submodule {
+          options.path = mkOption {
+            description = "Path to a folder to be added to the dock.";
+            type = types.str;
+          };
+          options.arrangement = mkOption {
+            description = "Sort order for files in folder when clicked.";
+            type = types.enum ["name" "date-added" "date-modified" "date-created" "kind"];
+            default = "name";
+          };
+          options.displayas = mkOption {
+            description = "How to display the folder before clicked.  stack: Stack of file previews.  folder: A folder icon";
+            type = types.enum ["stack" "folder"];
+            default = "stack";
+          };
+          options.showas = mkOption {
+            description = "Effect to show files when clicked.  fan: fan-out effect, grid: box, list: list";
+            type = types.enum ["automatic" "fan" "grid" "list"];
+            default = "automatic";
+          };
+        };
+        taggedType = types.attrTag {
+          file = mkOption {
+            description = "A file to be added to the dock.";
+            type = types.str;
+          };
+          folder = mkOption {
+            description = "A folder to be added to the dock.";
+            type = types.coercedTo types.str (str: { path = str; }) folderType;
+          };
+        };
+        simpleType = types.either types.str types.path;
+        # Below to NOT break exisiting config
+        toTagged = _path: let path = builtins.toString _path; in if strings.hasInfix "." (last (splitString "/" path)) then { file = path; } else { folder = path; };
+        # toTagged = path: { folder = path; }; # or this to be consistent with persistent-apps
+      in
+        types.nullOr (types.listOf (types.coercedTo simpleType toTagged taggedType));
       default = null;
-      example = [ "~/Documents" "~/Downloads" ];
+      example = [
+        ./flake.nix
+        "/Volumes"
+        { folder = "/Users/@username@/Downloads"; }
+        { folder = { path = "/Users/@username@/.emacs.d"; showas = "grid"; }; }
+        { file = "/Users/@username@/Desktop/this_is_a_file"; }
+      ];
       description = ''
-        Persistent folders in the dock.
+        Persistent files, and folders in the dock.
       '';
-      apply = value:
-        if !(isList value)
-        then value
-        else map (folder: { tile-data = { file-data = { _CFURLString = "file://" + folder; _CFURLStringType = 15; }; }; tile-type = if strings.hasInfix "." (last (splitString "/" folder)) then "file-tile" else "directory-tile"; }) value;
+      apply = let
+        arrangementMap = {
+          name          = 1;
+          date-added    = 2;
+          date-modified = 3;
+          date-created  = 4;
+          kind          = 5;
+        };
+        displayasMap = {
+          stack  = 0;
+          folder = 1;
+        };
+        showasMap = {
+          automatic = 0;
+          fan       = 1;
+          grid      = 2;
+          list      = 3;
+        };
+        parseFolder = (folder:
+          builtins.mapAttrs (name: val:
+            if name == "arrangement" then arrangementMap.${val}
+            else if name == "displayas" then displayasMap.${val}
+            else if name == "showas" then showasMap.${val}
+            else val
+          ) folder
+        );
+        toTile = item: {
+          tile-data = {
+            file-data = {
+              _CFURLString = "file://" + (if item ? folder then item.folder.path else item.file);
+              _CFURLStringType = 15;
+            };
+          } // (if item ? folder then {inherit (parseFolder item.folder) arrangement displayas showas;} else {});
+          tile-type = if item ? folder then "directory-tile" else "file-tile";
+        };
+      in
+        value: if value == null then null else map toTile value;
     };
 
     system.defaults.dock.scroll-to-open = mkOption {


### PR DESCRIPTION
This is backward compatible via conversion function provided for `coercedTo`.

Fixes: #968, #982, #1398

The old logic is as follows:  if ba

For this configuration:
```
  persistent-others = [
    ./.
    "/Volumes"
    { file = "/Volumes"; }
    "/Users/${username}/Desktop/this_is_a_file"
    { file = "/Users/${username}/Desktop/this_is_a_file"; }
    "/Users/${username}/.local/share/chezmoi/__.emacs.d"
    { folder = { path = "/Users/${username}/.local/share/chezmoi/__.emacs.d"; showas = "grid"; }; }
    "/Users/${username}/.emacs.d/"
    "/Users/${username}/.emacs.d"
    { folder = "/Users/${username}/Downloads"; }
  ];
```

In my computer, it wiill result in this:
![image](https://github.com/user-attachments/assets/155d1c78-10bd-447b-b5a1-e6e385abc4af)
- `./.` :: folder since `./.` is converted to a path like `/path/to/folder` so by the backward compatible logic it is a folder.
- `/Volumes` :: a folder
- 
  