### PR TITLE
feat: add option programs.zsh.enableAutosuggestions

### DIFF
--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -102,6 +102,12 @@ in
       description = "Enable fzf keybinding for Ctrl-r history search.";
     };
 
+    programs.zsh.enableAutosuggestions = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Enable zsh-autosuggestions.";
+    };
+
     programs.zsh.enableSyntaxHighlighting = mkOption {
       type = types.bool;
       default = false;
@@ -123,6 +129,7 @@ in
       [ # Include zsh package
         pkgs.zsh
       ] ++ optional cfg.enableCompletion pkgs.nix-zsh-completions
+        ++ optional cfg.enableAutosuggestions pkgs.zsh-autosuggestions
         ++ optional cfg.enableSyntaxHighlighting pkgs.zsh-syntax-highlighting
         ++ optional cfg.enableFastSyntaxHighlighting pkgs.zsh-fast-syntax-highlighting;
 
@@ -198,6 +205,10 @@ in
 
       ${optionalString cfg.enableGlobalCompInit "autoload -U compinit && compinit"}
       ${optionalString cfg.enableBashCompletion "autoload -U bashcompinit && bashcompinit"}
+
+      ${optionalString cfg.enableAutosuggestions
+        "source ${pkgs.zsh-autosuggestions}/share/zsh-autosuggestions/zsh-autosuggestions.zsh"
+      }
 
       ${optionalString cfg.enableSyntaxHighlighting
         "source ${pkgs.zsh-syntax-highlighting}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"

--- a/tests/programs-zsh.nix
+++ b/tests/programs-zsh.nix
@@ -8,6 +8,7 @@
    programs.zsh.enable = true;
    programs.zsh.enableCompletion = true;
    programs.zsh.enableBashCompletion = false;
+   programs.zsh.enableAutosuggestions = true;
 
    programs.zsh.shellInit = "source /etc/zshenv.d/*.conf";
    programs.zsh.interactiveShellInit = "source /etc/zshrc.d/*.conf";
@@ -35,6 +36,8 @@
      grep 'autoload -U compinit && compinit' ${config.out}/etc/zshrc
      echo >&2 "checking bashcompinit in /etc/zshrc"
      (! grep 'bashcompinit' ${config.out}/etc/zshrc)
+     echo >&2 "checking zsh-autosuggestions in /etc/zshrc"
+     grep 'source ${pkgs.zsh-autosuggestions}/share/zsh-autosuggestions/zsh-autosuggestions.zsh' ${config.out}/etc/zshrc
 
      echo >&2 "checking zprofile.d in /etc/zprofile"
      grep 'source /etc/zprofile.d/\*.conf' ${config.out}/etc/zprofile


### PR DESCRIPTION
We got `enableSyntaxHighlighting`, so why not `enableAutosuggestions` too?

Ref: #527

I have added tests too.
However, I saw the other "plugin" related options for `zsh` are NOT tested.
Should I remove my tests for any reasons? e.g. resource concern