### PR TITLE
programs/_1password{,-gui}: init modules

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -100,6 +100,7 @@
   ./services/nextdns
   ./services/jankyborders
   ./programs/_1password.nix
+  ./programs/_1password-gui.nix
   ./programs/bash
   ./programs/direnv.nix
   ./programs/fish.nix

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -99,6 +99,7 @@
   ./services/yabai
   ./services/nextdns
   ./services/jankyborders
+  ./programs/_1password.nix
   ./programs/bash
   ./programs/direnv.nix
   ./programs/fish.nix

--- a/modules/programs/_1password-gui.nix
+++ b/modules/programs/_1password-gui.nix
@@ -1,0 +1,49 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.programs._1password-gui;
+in
+{
+  options = {
+    programs._1password-gui = {
+      enable = lib.mkEnableOption "the 1Password GUI application";
+
+      package = lib.mkPackageOption pkgs "1Password GUI" {
+        default = [ "_1password-gui" ];
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # Based on https://github.com/reckenrode/nixos-configs/blob/22b8357fc6ffbd0df5ce50dc417c23a807a268a2/modules/by-name/1p/1password/darwin-module.nix
+    system.activationScripts.applications.text = lib.mkAfter ''
+      install -o root -g wheel -m0555 -d "/Applications/1Password.app"
+
+      rsyncFlags=(
+        # mtime is standardized in the nix store, which would leave only file size to distinguish files.
+        # Thus we need checksums, despite the speed penalty.
+        --checksum
+        # Converts all symlinks pointing outside of the copied tree (thus unsafe) into real files and directories.
+        # This neatly converts all the symlinks pointing to application bundles in the nix store into
+        # real directories, without breaking any relative symlinks inside of application bundles.
+        # This is good enough, because the make-symlinks-relative.sh setup hook converts all $out internal
+        # symlinks to relative ones.
+        --copy-unsafe-links
+        --archive
+        --delete
+        --chmod=-w
+        --no-group
+        --no-owner
+      )
+
+      ${lib.getExe pkgs.rsync} "''${rsyncFlags[@]}" \
+        ${pkgs._1password-gui}/Applications/1Password.app/ /Applications/1Password.app
+    '';
+  };
+}
+

--- a/modules/programs/_1password.nix
+++ b/modules/programs/_1password.nix
@@ -1,0 +1,31 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.programs._1password;
+in
+{
+  options = {
+    programs._1password = {
+      enable = lib.mkEnableOption "the 1Password CLI tool";
+
+      package = lib.mkPackageOption pkgs "1Password CLI" {
+        default = [ "_1password-cli" ];
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # Integration with the 1Password GUI will only work if the CLI at `/usr/local/bin/op`
+    # Based on https://github.com/reckenrode/nixos-configs/blob/22b8357fc6ffbd0df5ce50dc417c23a807a268a2/modules/by-name/1p/1password/darwin-module.nix
+    system.activationScripts.applications.text = lib.mkAfter ''
+      install -o root -g wheel -m0555 -D \
+        ${lib.getExe pkgs._1password-cli} /usr/local/bin/op
+    '';
+  };
+}
+


### PR DESCRIPTION
Based on @reckenrode's configs: https://github.com/reckenrode/nixos-configs/blob/22b8357fc6ffbd0df5ce50dc417c23a807a268a2/modules/by-name/1p/1password/darwin-module.nix

I didn't add any tests as these packages are unfree and I didn't think there's enough functionality worth testing here

The option names are to match NixOS, ideally the CLI module should probably be `programs._1password-cli` but we'll just wait for upstream on that

Fixes https://github.com/NixOS/nixpkgs/issues/254944