### PR TITLE
services/buildkite-agents: support multi-tags

### DIFF
--- a/modules/services/buildkite-agents.nix
+++ b/modules/services/buildkite-agents.nix
@@ -235,7 +235,13 @@ in
         ##     don't end up in the Nix store.
         script = let
           sshDir = "${cfg.dataDir}/.ssh";
-          tagStr = lib.concatStringsSep "," (lib.mapAttrsToList (name: value: "${name}=${value}") cfg.tags);
+          tagStr =
+            name: value:
+            if lib.isList value then
+              lib.concatStringsSep "," (builtins.map (v: "${name}=${v}") value)
+            else
+              "${name}=${value}";
+          tagsStr = lib.concatStringsSep "," (lib.mapAttrsToList tagStr cfg.tags);
         in
           optionalString (cfg.privateSshKeyPath != null) ''
             mkdir -m 0700 "${sshDir}"
@@ -245,7 +251,7 @@ in
             token="$(cat ${toString cfg.tokenPath})"
             name="${cfg.name}"
             shell="${cfg.shell}"
-            tags="${tagStr}"
+            tags="${tagsStr}"
             build-path="${cfg.dataDir}/builds"
             hooks-path="${cfg.hooksPath}"
             ${cfg.extraConfig}


### PR DESCRIPTION
This is essentially a port of https://github.com/NixOS/nixpkgs/pull/120209.

[#653](https://github.com/nix-darwin/nix-darwin/pull/653/files#diff-b19c4de0b41d99a49a7abbfa4676f8b82f48e99ffdc697dc10788a5e74ce9104R81) already used the correct option type, just the implementation was lacking.