### PR TITLE
darwin-rebuild: use `NIX_REMOTE=daemon` even as `root`

### DIFF
--- a/pkgs/nix-tools/darwin-rebuild.sh
+++ b/pkgs/nix-tools/darwin-rebuild.sh
@@ -11,6 +11,10 @@ fi
 export PATH=@path@
 export NIX_PATH=${NIX_PATH:-@nixPath@}
 
+# Use the daemon even as `root` so that resource limits, TLS and proxy
+# configuration, etc. work as expected.
+export NIX_REMOTE=${NIX_REMOTE:-daemon}
+
 showSyntax() {
   echo "darwin-rebuild [--help] {edit | switch | activate | build | check | changelog}" >&2
   echo "               [--list-generations] [{--profile-name | -p} name] [--rollback]" >&2


### PR DESCRIPTION
Should fix https://github.com/nix-darwin/nix-darwin/issues/1455#issuecomment-2891233216.