### PR TITLE
darwin-rebuild: try to re-run as root when needed

### DIFF
--- a/pkgs/nix-tools/darwin-rebuild.sh
+++ b/pkgs/nix-tools/darwin-rebuild.sh
@@ -144,7 +144,8 @@ if [ -z "$action" ]; then showSyntax; fi
 
 if [[ $action =~ ^switch|activate|rollback|check$ && $(id -u) -ne 0 ]]; then
   printf >&2 '%s: system activation must now be run as root\n' "$0"
-  exit 1
+  printf >&2 '%s: trying to re-run as root\n' "$0"
+  exec sudo "$0" "${origArgs[@]}"
 fi
 
 flakeFlags=(--extra-experimental-features 'nix-command flakes')


### PR DESCRIPTION
This would ease the transition to root activation, as many have encountered:
- #1457

Basically, just try to re-run the whole `darwin-rebuild` script as root when necessary.
- Tested and works great on my machine!
- However, is this safe? Maybe there are edge cases that we need to address? I am always afraid of `sudo`...