### PR TITLE
feat(services.openssh): add extraConfig option

### DIFF
--- a/modules/services/openssh.nix
+++ b/modules/services/openssh.nix
@@ -5,14 +5,25 @@ let
 in
 {
   options = {
-    services.openssh.enable = lib.mkOption {
-      type = lib.types.nullOr lib.types.bool;
-      default = null;
-      description = ''
-        Whether to enable Apple's built-in OpenSSH server.
+    services.openssh = {
+      enable = lib.mkOption {
+        type = lib.types.nullOr lib.types.bool;
+        default = null;
+        description = ''
+          Whether to enable Apple's built-in OpenSSH server.
 
-        The default is null which means let macOS manage the OpenSSH server.
-      '';
+          The default is null which means let macOS manage the OpenSSH server.
+        '';
+      };
+
+      extraConfig = lib.mkOption {
+        type = lib.types.lines;
+        default = "";
+        description = ''
+          Extra configuration text loaded in {file}`sshd_config`.
+          See {manpage}`sshd_config(5)` for help.
+        '';
+      };
     };
   };
 
@@ -29,5 +40,7 @@ in
         launchctl disable system/com.openssh.sshd
       fi
     '');
+
+    environment.etc."ssh/sshd_config.d/100-nix-darwin.conf".text = cfg.extraConfig;
   };
 }

--- a/release.nix
+++ b/release.nix
@@ -111,6 +111,7 @@ in {
   tests.services-netdata = makeTest ./tests/services-netdata.nix;
   tests.services-ofborg = makeTest ./tests/services-ofborg.nix;
   tests.services-offlineimap = makeTest ./tests/services-offlineimap.nix;
+  tests.services-openssh = makeTest ./tests/services-openssh.nix;
   tests.services-privoxy = makeTest ./tests/services-privoxy.nix;
   tests.services-redis = makeTest ./tests/services-redis.nix;
   tests.services-skhd = makeTest ./tests/services-skhd.nix;

--- a/tests/services-openssh.nix
+++ b/tests/services-openssh.nix
@@ -1,0 +1,12 @@
+{ config, pkgs, ... }:
+
+{
+  services.openssh.extraConfig = ''
+    StreamLocalBindUnlink yes
+  '';
+
+  test = ''
+    echo >&2 "checking for StreamLocalBindUnlink in /etc/ssh/ssh_known_hosts"
+    grep 'StreamLocalBindUnlink yes' ${config.out}/etc/ssh/sshd_config.d/100-nix-darwin.conf
+  '';
+}


### PR DESCRIPTION
Same interface as in NixOS: https://search.nixos.org/options?channel=unstable&show=services.openssh.extraConfig&from=0&size=50&sort=relevance&type=packages&query=services.openssh.extraConfig
This is useful to customize the behavior of the SSH daemon, e.g. to add
options like `StreamLocalBindUnlink yes` to improve gpg-agent
forwarding.

Signed-off-by: squat <lserven@gmail.com>
