### PR TITLE
[24.11] `system.build`: Treat as variables, make lazy, fix error message

### DIFF
--- a/modules/system/default.nix
+++ b/modules/system/default.nix
@@ -20,7 +20,7 @@ in
 
     system.build = mkOption {
       internal = true;
-      type = types.attrsOf types.unspecified;
+      type = types.lazyAttrsOf types.unspecified;
       default = {};
       description = ''
         Attribute set of derivation used to setup the system.


### PR DESCRIPTION
- Backport of #1468 