### PR TITLE
feat(services.openssh): add settings

### DIFF
--- a/modules/services/openssh.nix
+++ b/modules/services/openssh.nix
@@ -1,7 +1,83 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 let
   cfg = config.services.openssh;
+  # Lifted from nixpkgs: https://github.com/squat/nixpkgs/blob/e52d633a638c607533ececf4eb9653ec1f93e3d4/nixos/modules/services/networking/ssh/sshd.nix#L20-L78.
+  settingsFormat =
+    let
+      # reports boolean as yes / no
+      mkValueString =
+        v:
+        if lib.isInt v then
+          toString v
+        else if lib.isString v then
+          v
+        else if true == v then
+          "yes"
+        else if false == v then
+          "no"
+        else
+          throw "unsupported type ${builtins.typeOf v}: ${(lib.generators.toPretty { }) v}";
+
+      base = pkgs.formats.keyValue {
+        mkKeyValue = lib.generators.mkKeyValueDefault { inherit mkValueString; } " ";
+      };
+      # OpenSSH is very inconsistent with options that can take multiple values.
+      # For some of them, they can simply appear multiple times and are appended, for others the
+      # values must be separated by whitespace or even commas.
+      # Consult either sshd_config(5) or, as last resort, the OpehSSH source for parsing
+      # the options at servconf.c:process_server_config_line_depth() to determine the right "mode"
+      # for each. But fortunaly this fact is documented for most of them in the manpage.
+      commaSeparated = [
+        "Ciphers"
+        "KexAlgorithms"
+        "MACs"
+      ];
+      spaceSeparated = [
+        "AuthorizedKeysFile"
+        "AllowGroups"
+        "AllowUsers"
+        "DenyGroups"
+        "DenyUsers"
+        "Include"
+        "Subsystem"
+      ];
+    in
+    {
+      inherit (base) type;
+      generate =
+        name: value:
+        let
+          transformedValue = lib.mapAttrs (
+            key: val:
+            if lib.isList val then
+              if lib.elem key commaSeparated then
+                lib.concatStringsSep "," val
+              else if lib.elem key spaceSeparated then
+                lib.concatStringsSep " " val
+              else
+                throw "list value for unknown key ${key}: ${(lib.generators.toPretty { }) val}"
+            else
+              val
+          ) value;
+        in
+        base.generate name transformedValue;
+    };
+
+  sshConfSettings = settingsFormat.generate "sshd.conf-settings" (
+    lib.filterAttrs (n: v: v != null) cfg.settings
+  );
+  sshConfNixDarwin = pkgs.runCommand "sshd.conf-nix-darwin" { } ''
+    cat ${sshConfSettings} - > $out <<EOF
+    ${cfg.extraConfig}
+    EOF
+  '';
+
 in
 {
   options = {
@@ -24,23 +100,279 @@ in
           See {manpage}`sshd_config(5)` for help.
         '';
       };
+
+      settings = lib.mkOption {
+        description = "Configuration for `sshd_config(5)`.";
+        default = { };
+        example = lib.literalExpression ''
+          {
+            UseDns = true;
+            PasswordAuthentication = false;
+          }
+        '';
+        type = lib.types.submodule (
+          { name, ... }:
+          {
+            freeformType = settingsFormat.type;
+            options = {
+              AuthorizedPrincipalsFile = lib.mkOption {
+                type = lib.types.nullOr lib.types.str;
+                default = "none"; # upstream default
+                description = ''
+                  Specifies a file that lists principal names that are accepted for certificate authentication. The default
+                  is `"none"`, i.e. not to use	a principals file.
+                '';
+              };
+              LogLevel = lib.mkOption {
+                type = lib.types.nullOr (
+                  lib.types.enum [
+                    "QUIET"
+                    "FATAL"
+                    "ERROR"
+                    "INFO"
+                    "VERBOSE"
+                    "DEBUG"
+                    "DEBUG1"
+                    "DEBUG2"
+                    "DEBUG3"
+                  ]
+                );
+                default = "INFO"; # upstream default
+                description = ''
+                  Gives the verbosity level that is used when logging messages from {manpage}`sshd(8)`. Logging with a DEBUG level
+                  violates the privacy of users and is not recommended.
+                '';
+              };
+              UsePAM = lib.mkEnableOption "PAM authentication" // {
+                default = false; # upstream default
+                type = lib.types.nullOr lib.types.bool;
+              };
+              UseDns = lib.mkOption {
+                type = lib.types.nullOr lib.types.bool;
+                default = false;
+                description = ''
+                  Specifies whether {manpage}`sshd(8)` should look up the remote host name, and to check that the resolved host name for
+                  the remote IP address maps back to the very same IP address.
+                  If this option is set to no (the default) then only addresses and not host names may be used in
+                  ~/.ssh/authorized_keys from and sshd_config Match Host directives.
+                '';
+              };
+              X11Forwarding = lib.mkOption {
+                type = lib.types.nullOr lib.types.bool;
+                default = false; # upstream default
+                description = ''
+                  Whether to allow X11 connections to be forwarded.
+                '';
+              };
+              PasswordAuthentication = lib.mkOption {
+                type = lib.types.nullOr lib.types.bool;
+                default = true; # upstream default
+                description = ''
+                  Specifies whether password authentication is allowed.
+                '';
+              };
+              PermitRootLogin = lib.mkOption {
+                default = "prohibit-password"; # upstream default
+                type = lib.types.nullOr (
+                  lib.types.enum [
+                    "yes"
+                    "without-password"
+                    "prohibit-password"
+                    "forced-commands-only"
+                    "no"
+                  ]
+                );
+                description = ''
+                  Whether the root user can login using ssh.
+                '';
+              };
+              KbdInteractiveAuthentication = lib.mkOption {
+                type = lib.types.nullOr lib.types.bool;
+                default = true; # upstream default
+                description = ''
+                  Specifies whether keyboard-interactive authentication is allowed.
+                '';
+              };
+              GatewayPorts = lib.mkOption {
+                type = lib.types.nullOr lib.types.str;
+                default = "no"; # upstream default
+                description = ''
+                  Specifies whether remote hosts are allowed to connect to
+                  ports forwarded for the client.  See
+                  {manpage}`sshd_config(5)`.
+                '';
+              };
+              KexAlgorithms = lib.mkOption {
+                type = lib.types.nullOr (lib.types.listOf lib.types.str);
+                default = [
+                  "mlkem768x25519-sha256"
+                  "sntrup761x25519-sha512"
+                  "sntrup761x25519-sha512@openssh.com"
+                  "curve25519-sha256"
+                  "curve25519-sha256@libssh.org"
+                  "diffie-hellman-group-exchange-sha256"
+                ]; # NixOS default for security
+                description = ''
+                  Allowed key exchange algorithms
+
+                  Uses the lower bound recommended in both
+                  <https://stribika.github.io/2015/01/04/secure-secure-shell.html>
+                  and
+                  <https://infosec.mozilla.org/guidelines/openssh#modern-openssh-67>
+                '';
+              };
+              MACs = lib.mkOption {
+                type = lib.types.nullOr (lib.types.listOf lib.types.str);
+                default = [
+                  "hmac-sha2-512-etm@openssh.com"
+                  "hmac-sha2-256-etm@openssh.com"
+                  "umac-128-etm@openssh.com"
+                ]; # NixOS default for security
+                description = ''
+                  Allowed MACs
+
+                  Defaults to recommended settings from both
+                  <https://stribika.github.io/2015/01/04/secure-secure-shell.html>
+                  and
+                  <https://infosec.mozilla.org/guidelines/openssh#modern-openssh-67>
+                '';
+              };
+              StrictModes = lib.mkOption {
+                type = lib.types.nullOr (lib.types.bool);
+                default = true; # upstream default
+                description = ''
+                  Whether sshd should check file modes and ownership of directories
+                '';
+              };
+              Ciphers = lib.mkOption {
+                type = lib.types.nullOr (lib.types.listOf lib.types.str);
+                default = [
+                  "chacha20-poly1305@openssh.com"
+                  "aes256-gcm@openssh.com"
+                  "aes128-gcm@openssh.com"
+                  "aes256-ctr"
+                  "aes192-ctr"
+                  "aes128-ctr"
+                ]; # upstream default
+                description = ''
+                  Allowed ciphers
+
+                  Defaults to recommended settings from both
+                  <https://stribika.github.io/2015/01/04/secure-secure-shell.html>
+                  and
+                  <https://infosec.mozilla.org/guidelines/openssh#modern-openssh-67>
+                '';
+              };
+              AllowUsers = lib.mkOption {
+                type = lib.types.nullOr (lib.types.listOf lib.types.str);
+                default = null; # upstream default
+                description = ''
+                  If specified, login is allowed only for the listed users.
+                  See {manpage}`sshd_config(5)` for details.
+                '';
+              };
+              DenyUsers = lib.mkOption {
+                type = lib.types.nullOr (lib.types.listOf lib.types.str);
+                default = null; # upstream default
+                description = ''
+                  If specified, login is denied for all listed users. Takes
+                  precedence over [](#opt-services.openssh.settings.AllowUsers).
+                  See {manpage}`sshd_config(5)` for details.
+                '';
+              };
+              AllowGroups = lib.mkOption {
+                type = lib.types.nullOr (lib.types.listOf lib.types.str);
+                default = null; # upstream default
+                description = ''
+                  If specified, login is allowed only for users part of the
+                  listed groups.
+                  See {manpage}`sshd_config(5)` for details.
+                '';
+              };
+              DenyGroups = lib.mkOption {
+                type = lib.types.nullOr (lib.types.listOf lib.types.str);
+                default = null; # upstream default
+                description = ''
+                  If specified, login is denied for all users part of the listed
+                  groups. Takes precedence over
+                  [](#opt-services.openssh.settings.AllowGroups). See
+                  {manpage}`sshd_config(5)` for details.
+                '';
+              };
+              PrintMotd = lib.mkOption {
+                type = lib.types.nullOr lib.types.bool;
+                default = true; # upstream default
+                description = ''
+                  Specifies whether sshd should print /etc/motd when a user logs in interactively.
+                '';
+              };
+              Include = lib.mkOption {
+                type = lib.types.nullOr (lib.types.listOf lib.types.str);
+                default = null;
+                description = ''
+                  Include  the  specified  configuration file(s).
+                  Multiple pathnames may be specified and each pathname may contain glob(7)
+                  wildcards that will be expanded and processed in lexical order.
+                  Files without absolute paths are assumed to be in /etc/ssh.
+                '';
+              };
+              Subsystem = lib.mkOption {
+                type = lib.types.nullOr (lib.types.listOf lib.types.str);
+                default = [
+                  "sftp"
+                  "/usr/libexec/sftp-server"
+                ]; # macOS default
+                description = ''
+                  Configures an external subsystem (e.g. file transfer daemon).
+                  Arguments  should be a subsystem name and a command
+                  (with optional arguments) to execute upon subsystem request.
+                '';
+              };
+              PubkeyAuthentication = lib.mkOption {
+                type = lib.types.nullOr (lib.types.bool);
+                default = true; # upstream default
+                description = ''
+                  Whether sshd should allow public key authentication
+                '';
+              };
+              AuthorizedKeysFile = lib.mkOption {
+                type = lib.types.nullOr (lib.types.listOf lib.types.str);
+                default = [ ".ssh/authorized_keys" ]; # macOS default
+                description = ''
+                  Specifies a file that lists principal names that are accepted for certificate authentication. The default
+                  is `"none"`, i.e. not to use	a principals file.
+                '';
+              };
+            };
+          }
+        );
+      };
     };
   };
 
   config = {
     # We don't use `systemsetup -setremotelogin` as it requires Full Disk Access
-    system.activationScripts.launchd.text = lib.mkIf (cfg.enable != null) (if cfg.enable then ''
-      if [[ "$(systemsetup -getremotelogin | sed 's/Remote Login: //')" == "Off" ]]; then
-        launchctl enable system/com.openssh.sshd
-        launchctl bootstrap system /System/Library/LaunchDaemons/ssh.plist
-      fi
-    '' else ''
-      if [[ "$(systemsetup -getremotelogin | sed 's/Remote Login: //')" == "On" ]]; then
-        launchctl bootout system/com.openssh.sshd
-        launchctl disable system/com.openssh.sshd
-      fi
-    '');
+    system.activationScripts.launchd.text = lib.mkIf (cfg.enable != null) (
+      if cfg.enable then
+        ''
+          if [[ "$(systemsetup -getremotelogin | sed 's/Remote Login: //')" == "Off" ]]; then
+            launchctl enable system/com.openssh.sshd
+            launchctl bootstrap system /System/Library/LaunchDaemons/ssh.plist
+          fi
+        ''
+      else
+        ''
+          if [[ "$(systemsetup -getremotelogin | sed 's/Remote Login: //')" == "On" ]]; then
+            launchctl bootout system/com.openssh.sshd
+            launchctl disable system/com.openssh.sshd
+          fi
+        ''
+    );
 
-    environment.etc."ssh/sshd_config.d/100-nix-darwin.conf".text = cfg.extraConfig;
+    environment.etc."ssh/sshd_config.d/100-nix-darwin.conf".source = sshConfNixDarwin;
+
+    system.checks.text = lib.mkAfter ''
+      ${pkgs.openssh.override { withPAM = true; }}/bin/sshd -G -T -f ${sshConfNixDarwin} > /dev/null
+    '';
   };
 }

--- a/release.nix
+++ b/release.nix
@@ -1,25 +1,33 @@
-{ nixpkgs ? <nixpkgs>
-# Adapted from https://github.com/NixOS/nixpkgs/blob/e818264fe227ad8861e0598166cf1417297fdf54/pkgs/top-level/release.nix#L11
-, nix-darwin ? { }
-, system ? builtins.currentSystem
-, supportedSystems ? [ "x86_64-darwin" "aarch64-darwin" ]
-, scrubJobs ? true
+{
+  nixpkgs ? <nixpkgs>,
+  # Adapted from https://github.com/NixOS/nixpkgs/blob/e818264fe227ad8861e0598166cf1417297fdf54/pkgs/top-level/release.nix#L11
+  nix-darwin ? { },
+  system ? builtins.currentSystem,
+  supportedSystems ? [
+    "x86_64-darwin"
+    "aarch64-darwin"
+  ],
+  scrubJobs ? true,
 }:
 
 let
-  buildFromConfig = configuration: sel: sel
-    (import ./. { inherit nixpkgs configuration system; }).config;
+  buildFromConfig =
+    configuration: sel: sel (import ./. { inherit nixpkgs configuration system; }).config;
 
   makeSystem = configuration: buildFromConfig configuration (config: config.system.build.toplevel);
 
-  makeTest = test:
+  makeTest =
+    test:
     let
-      testName =
-        builtins.replaceStrings [ ".nix" ] [ "" ]
-          (builtins.baseNameOf test);
+      testName = builtins.replaceStrings [ ".nix" ] [ "" ] (builtins.baseNameOf test);
 
       configuration =
-        { config, lib, pkgs, ... }:
+        {
+          config,
+          lib,
+          pkgs,
+          ...
+        }:
         with lib;
         {
           imports = [ test ];
@@ -37,39 +45,49 @@ let
           config = {
             system.stateVersion = lib.mkDefault config.system.maxStateVersion;
 
-            system.build.run-test = pkgs.runCommand "darwin-test-${testName}"
-              { allowSubstitutes = false; preferLocalBuild = true; }
-              ''
-                #! ${pkgs.stdenv.shell}
-                set -e
+            system.build.run-test =
+              pkgs.runCommand "darwin-test-${testName}"
+                {
+                  allowSubstitutes = false;
+                  preferLocalBuild = true;
+                }
+                ''
+                  #! ${pkgs.stdenv.shell}
+                  set -e
 
-                echo >&2 "running tests for system ${config.out}"
-                echo >&2
-                ${config.test}
-                echo >&2 ok
-                touch $out
-              '';
+                  echo >&2 "running tests for system ${config.out}"
+                  echo >&2
+                  ${config.test}
+                  echo >&2 ok
+                  touch $out
+                '';
 
             out = config.system.build.toplevel;
           };
         };
     in
-      buildFromConfig configuration (config: config.system.build.run-test);
+    buildFromConfig configuration (config: config.system.build.run-test);
 
-  manual = buildFromConfig ({ lib, config, ... }: {
-    system.stateVersion = lib.mkDefault config.system.maxStateVersion;
+  manual = buildFromConfig (
+    { lib, config, ... }:
+    {
+      system.stateVersion = lib.mkDefault config.system.maxStateVersion;
 
-    system.darwinVersionSuffix = let
-      shortRev = nix-darwin.shortRev or nix-darwin.dirtyShortRev or null;
-    in
-      lib.mkIf (shortRev != null) ".${shortRev}";
-    system.darwinRevision = let
-      rev = nix-darwin.rev or nix-darwin.dirtyRev or null;
-    in
-      lib.mkIf (rev != null) rev;
-  }) (config: config.system.build.manual);
+      system.darwinVersionSuffix =
+        let
+          shortRev = nix-darwin.shortRev or nix-darwin.dirtyShortRev or null;
+        in
+        lib.mkIf (shortRev != null) ".${shortRev}";
+      system.darwinRevision =
+        let
+          rev = nix-darwin.rev or nix-darwin.dirtyRev or null;
+        in
+        lib.mkIf (rev != null) rev;
+    }
+  ) (config: config.system.build.manual);
 
-in {
+in
+{
   docs = {
     inherit (manual) manualHTML manpages optionsJSON;
   };
@@ -112,6 +130,7 @@ in {
   tests.services-ofborg = makeTest ./tests/services-ofborg.nix;
   tests.services-offlineimap = makeTest ./tests/services-offlineimap.nix;
   tests.services-openssh = makeTest ./tests/services-openssh.nix;
+  tests.services-openssh-empty = makeTest ./tests/services-openssh-empty.nix;
   tests.services-privoxy = makeTest ./tests/services-privoxy.nix;
   tests.services-redis = makeTest ./tests/services-redis.nix;
   tests.services-skhd = makeTest ./tests/services-skhd.nix;

--- a/tests/services-openssh-empty.nix
+++ b/tests/services-openssh-empty.nix
@@ -1,0 +1,8 @@
+{ config, ... }:
+
+{
+  test = ''
+    echo >&2 "checking for macOS defaults in /etc/ssh/sshd_config"
+    grep --fixed-strings 'AuthorizedKeysFile .ssh/authorized_keys' ${config.out}/etc/ssh/sshd_config.d/100-nix-darwin.conf
+  '';
+}

--- a/tests/services-openssh.nix
+++ b/tests/services-openssh.nix
@@ -1,12 +1,29 @@
-{ config, pkgs, ... }:
+{ config, ... }:
 
 {
   services.openssh.extraConfig = ''
     StreamLocalBindUnlink yes
   '';
 
+  services.openssh.settings = {
+    MACs = [
+      "hmac-sha2-512-etm@openssh.com"
+      "hmac-sha2-256-etm@openssh.com"
+    ];
+    AllowGroups = [
+      "foo"
+      "bar"
+    ];
+  };
+
   test = ''
-    echo >&2 "checking for StreamLocalBindUnlink in /etc/ssh/ssh_known_hosts"
+    echo >&2 "checking for StreamLocalBindUnlink in /etc/ssh/sshd_config.d/100-nix-darwin.conf"
     grep 'StreamLocalBindUnlink yes' ${config.out}/etc/ssh/sshd_config.d/100-nix-darwin.conf
+
+    echo >&2 "checking for correct comma-separation in /etc/ssh/sshd_config.d/100-nix-darwin.conf"
+    grep --fixed-strings 'MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com' ${config.out}/etc/ssh/sshd_config.d/100-nix-darwin.conf
+
+    echo >&2 "checking for correct space-separation in /etc/ssh/sshd_config.d/100-nix-darwin.conf"
+    grep --fixed-strings 'AllowGroups foo bar' ${config.out}/etc/ssh/sshd_config.d/100-nix-darwin.conf
   '';
 }


### PR DESCRIPTION
This commit introduces the `settings` option to configure OpenSSH.
Most of the configuration options are lifted verbatim from
https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/networking/ssh/sshd.nix
with a few exceptions:
1. `Macs` is renamed to `MACs` to comply with the upstream OpenSSH
   directive name;
1. `PubkeyAuthentication` is introduced; this directive defaults to `no`
   on the OpenSSH version shipped with NixOS but defaults to `yes` on
   the OpenSSH version shipped with macOS;
1. `Include` is introduced in order to mirror the default macOS
   configuration, which differs from the upstream OpenSSH default;
1. `Subsystem` is introduced in order to mirror the default macOS
   configuration, which differs from the upstream OpenSSH default;
1. `AuthorizedKeyFiles` is set to `[ ".ssh/authorized_keys" ]` to mirror
   the default macOS configuration, which differs from the upstream
   OpenSSH default.
1. `UsePAM` defaults to `yes` on NixOS but defaults to `no`
   on the OpenSSH version shipped with NixOS but defaults to `yes` on
   the OpenSSH version shipped with macOS;

Other notable settings:
1. `KeyAlgorithms` uses the NixOS default rather than the default from
   the OpenSSH version that ships with macOS for better security.
1. `MACs` uses the NixOS default rather than the default from
   the OpenSSH version that ships with macOS for better security.

Signed-off-by: squat <lserven@gmail.com>
