### PR TITLE
config/terminfo: init module

### DIFF
--- a/modules/config/terminfo.nix
+++ b/modules/config/terminfo.nix
@@ -1,0 +1,89 @@
+# This module manages the terminfo database
+# and its integration in the system.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+
+  options = {
+    environment.enableAllTerminfo = lib.mkOption {
+      default = false;
+      type = lib.types.bool;
+      description = ''
+        Whether to install all terminfo outputs
+      '';
+    };
+
+    security.sudo.keepTerminfo = lib.mkOption {
+      default = true;
+      type = lib.types.bool;
+      description = ''
+        Whether to preserve the `TERMINFO` and `TERMINFO_DIRS`
+        environment variables, for `root` and the `admin` group.
+      '';
+    };
+  };
+
+  config = {
+
+    # This should not contain packages that are broken or can't build, since it
+    # will break this expression
+    #
+    # can be generated with:
+    # lib.attrNames (lib.filterAttrs
+    #  (_: drv: (builtins.tryEval (
+    #    lib.isDerivation drv && drv ? terminfo && drv.meta.available && !drv.meta.broken && !drv.meta.unsupported)).value)
+    #  pkgs)
+    environment.systemPackages = lib.mkIf config.environment.enableAllTerminfo (
+      map (x: x.terminfo) (
+        with pkgs.pkgsBuildBuild;
+        [
+          alacritty
+          kitty
+          mtm
+          rio
+          rxvt-unicode-unwrapped
+          rxvt-unicode-unwrapped-emoji
+          st
+          termite
+          tmux
+          wezterm
+        ] ++ lib.optional (pkgs ? ghostty-bin) ghostty-bin
+      )
+    );
+
+    environment.pathsToLink = [
+      "/share/terminfo"
+    ];
+
+    environment.etc.terminfo = {
+      source = "${config.system.path}/share/terminfo";
+    };
+
+    # TODO: use `environment.profileRelativeSessionVariables`
+    environment.variables = {
+      TERMINFO_DIRS = map (path: path + "/share/terminfo") config.environment.profiles ++ [ "/usr/share/terminfo" ];
+    };
+
+    environment.extraInit = ''
+      # reset TERM with new TERMINFO available (if any)
+      export TERM=$TERM
+    '';
+
+    security =
+      let
+        extraConfig = ''
+
+          # Keep terminfo database for root and %admin.
+          Defaults:root,%admin env_keep+=TERMINFO_DIRS
+          Defaults:root,%admin env_keep+=TERMINFO
+        '';
+      in
+      lib.mkIf config.security.sudo.keepTerminfo {
+        sudo = { inherit extraConfig; };
+      };
+  };
+}

--- a/modules/environment/default.nix
+++ b/modules/environment/default.nix
@@ -199,13 +199,9 @@ in
     environment.pathsToLink = [
       "/bin"
       "/share/locale"
-      "/share/terminfo"
     ];
 
     environment.extraInit = ''
-       # reset TERM with new TERMINFO available (if any)
-       export TERM=$TERM
-
        export NIX_USER_PROFILE_DIR="/nix/var/nix/profiles/per-user/$USER"
        export NIX_PROFILES="${concatStringsSep " " (reverseList cfg.profiles)}"
     '';
@@ -214,7 +210,6 @@ in
       {
         XDG_CONFIG_DIRS = map (path: path + "/etc/xdg") cfg.profiles;
         XDG_DATA_DIRS = map (path: path + "/share") cfg.profiles;
-        TERMINFO_DIRS = map (path: path + "/share/terminfo") cfg.profiles ++ [ "/usr/share/terminfo" ];
         EDITOR = mkDefault "nano";
         PAGER = mkDefault "less -R";
       };

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -1,5 +1,6 @@
 [
   ./alias.nix
+  ./config/terminfo.nix
   ./documentation
   ./meta.nix
   ./misc/ids.nix

--- a/tests/environment-terminfo.nix
+++ b/tests/environment-terminfo.nix
@@ -1,10 +1,18 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ config, ... }:
 
 {
+  environment.enableAllTerminfo = true;
+
   test = ''
+    set -v
+
     echo checking /usr/share/terminfo in environment >&2
     grep 'export TERMINFO_DIRS=.*:/usr/share/terminfo' ${config.system.build.setEnvironment}
+
+    # https://serverfault.com/a/225827
+    echo checking /etc/terminfo contains lots of terminfos >&2
+    find -L ${config.system.path} -name alacritty | grep .
+    find -L ${config.system.path} -name xterm-kitty | grep .
+    find -L ${config.system.path} -name wezterm | grep .
   '';
 }


### PR DESCRIPTION
Nearly 1:1 copy of the NixOS module: https://github.com/NixOS/nixpkgs/blob/2795c506fe8fb7b03c36ccb51f75b6df0ab2553f/nixos/modules/config/terminfo.nix

The main differences are we don't have `environment.profileRelativeSessionVariables` yet, macOS uses the `admin` group instead of `wheel` and we don't have `sudo-rs`