### PR TITLE
Preserve `PATH` variable when using `sudo` for Homebrew

### DIFF
--- a/modules/homebrew.nix
+++ b/modules/homebrew.nix
@@ -802,6 +802,7 @@ in
       if [ -f "${cfg.brewPrefix}/brew" ]; then
         PATH="${cfg.brewPrefix}:${lib.makeBinPath [ pkgs.mas ]}:$PATH" \
         sudo \
+          --preserve-env=PATH \
           --user=${escapeShellArg cfg.user} \
           --set-home \
           ${cfg.onActivation.brewBundleCmd}

--- a/modules/homebrew.nix
+++ b/modules/homebrew.nix
@@ -805,6 +805,7 @@ in
           --preserve-env=PATH \
           --user=${escapeShellArg cfg.user} \
           --set-home \
+          env \
           ${cfg.onActivation.brewBundleCmd}
       else
         echo -e "\e[1;31merror: Homebrew is not installed, skipping...\e[0m" >&2


### PR DESCRIPTION
Some systems set `secure_path` in sudoers. When this is set
the `PATH` variable is not set in the sudo environment. Using
`--preserve-env=PATH` and wrapping the call with `env` ensures that the PATH env var is set properly in those systems.

This is similar to the issue with [darwin-rebuild](https://github.com/nix-darwin/nix-darwin/issues/798) not working with sudo on these systems.