### PR TITLE
services/bluebubbles-server: init module

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -62,6 +62,7 @@
   ./services/activate-system
   ./services/aerospace
   ./services/autossh.nix
+  ./services/bluebubbles-server
   ./services/buildkite-agents.nix
   ./services/chunkwm.nix
   ./services/cachix-agent.nix

--- a/modules/services/bluebubbles-server/default.nix
+++ b/modules/services/bluebubbles-server/default.nix
@@ -1,0 +1,365 @@
+{config, lib, pkgs, ...}:
+with lib;
+let 
+  inherit (import ./settings.nix { inherit lib pkgs; }) settingsModule;
+
+  mkSecret = description: mkOption {
+    type = types.nullOr types.path;
+    default = null;
+    inherit description;
+    example = "/run/secrets/sops-secret";
+    # ensure it isn't added to the store
+    apply = final: if final == null then null else toString final;
+  };
+
+  secretsModule.options = {
+    password = mkSecret ''
+      Path to file containing password value, "for clients to authenticate with the server". 
+      A password must be set here or through the GUI. 
+    '';
+    ngrok_key = mkSecret ''
+      Path to file containing ngrok_key value. "Using an Auth Token will allow you to use the benefits of the upgraded Ngrok
+      service. This can improve connection stability and reliability. It is highly
+      recommended that you setup an auth token, especially if you are having connection
+      issues. If you do not have an Ngrok Account, sign up for free here:
+      https://dashboard.ngrok.com/get-started/your-authtoken"
+    '';
+    zrok_token = mkSecret ''
+      Path to file containing zrok_token value. 
+      "A Zrok Token is required to use the Zrok proxy service. 
+      If you do not have one, you can sign up for a free account within BlueBubbles"
+    '';
+    zrok_reserved_token = mkSecret ''
+      Path to file containing zrok_reserved_token value. No upstream documentation available.
+    '';
+  };
+
+  # present while bluebubbles-server is running
+  lockPath = "Library/Application Support/bluebubbles-server/SingletonLock";
+  logDir = "Library/Logs/bluebubbles-server";
+  exePath = "Applications/BlueBubbles.app/Contents/MacOS/BlueBubbles";
+  # upstream appId is `com.BlueBubbles.BlueBubbles-Server`, but website is `https://bluebubbles.app`.
+  # (https://github.com/BlueBubblesApp/bluebubbles-server/blob/95204ac18513fffcbb76cafed26008952e8346b3/packages/server/scripts/electron-builder-config.js#L5)
+  # to conform with reverse domain name notation, I'm opting to use `app.bluebubbles.*` for LaunchAgents
+  agentPrefix = "app.bluebubbles";
+
+  cfg = config.services.bluebubbles-server;
+in
+{
+  options.services.bluebubbles-server = {
+    enable = mkEnableOption "BlueBubbles Server";
+    package = mkPackageOption pkgs "bluebubbles-server" { };
+    settings = mkOption {
+      default = { };
+      description = ''
+        Settings for the server; passed as CLI args.
+      '';
+      example = literalExpression ''
+        {
+          socket_port = 1234;
+          server_address = "https://imsg.my-website.com";
+          proxy_service = "dynamic-dns";
+
+          enable_private_api = true;
+          enable_ft_private_api = true;
+
+          auto_caffeinate = true;
+          open_findmy_on_startup = true;
+          auto_lock_mac = true;
+
+          headless = true;
+          hide_dock_icon = true;
+          dock_badge = false;
+
+          tutorial_is_done = true;
+          check_for_updates = false;
+        }
+      '';
+      type = types.submoduleWith { modules = [settingsModule]; };
+    };
+
+    secretFiles = mkOption {
+      type = types.submoduleWith { modules = [ secretsModule ]; };
+      default = { };
+      description = ''
+        Files providing secrets for the server. 
+        Passed as CLI args at launch: `--secret-key-name=$(<"secret-file-path")`
+      '';
+    };
+
+    webhooks = mkOption {
+      type = types.listOf (types.submodule {
+        options = {
+          url = mkOption {
+            type = types.str;
+            default = null;
+            example = "https://ntfy-sh.my-website.com/upasdfQ1FZ9LOX?up=1";
+            description = ''
+              URL for the webhook
+            '';
+          };
+          events = mkOption {
+            # events can be either all (["*"]) or one of
+            # https://github.com/BlueBubblesApp/bluebubbles-server/blob/95204ac18513fffcbb76cafed26008952e8346b3/packages/server/src/server/events.ts
+            # better way to represent literal ["*"]?
+            type = with types; either (listOf (enum ["*"])) (listOf (enum [
+              "scheduled-message-error"
+              "scheduled-message-sent"
+              "scheduled-message-deleted"
+              "scheduled-message-updated"
+              "scheduled-message-created"
+              "new-message"
+              "message-send-error"
+              "updated-message"
+              "new-server"
+              "participant-removed"
+              "participant-added"
+              "participant-left"
+              "group-icon-changed"
+              "group-icon-removed"
+              "chat-read-status-changed"
+              "hello-world"
+              "typing-indicator"
+              "server-update"
+              "server-update-downloading"
+              "server-update-installing"
+              "group-name-change"
+              "incoming-facetime"
+              "settings-backup-created"
+              "settings-backup-deleted"
+              "settings-backup-updated"
+              "theme-backup-created"
+              "theme-backup-deleted"
+              "theme-backup-updated"
+              "imessage-aliases-removed"
+              "ft-call-status-changed"
+              "new-findmy-location"
+            ]));
+            default = ["*"];
+            example = [ "new-message" "updated-message" ];
+            description = ''
+              List of events to subscribe to for this webhook. 
+              Use `["*"]` to subscribe to all events.
+            '';
+          };
+        };
+      });
+      default = [ ];
+      example = literalExpression ''
+        [
+          {
+            url = "https://ntfy-sh.my-website.com/upasdfQ1FZ9LOX?up=1";
+            events = [ "*" ]; # all events
+          }
+          {
+            url = "https://example.com/webhook";
+            events = [ "new-message" "updated-message" ];
+          }
+        ]
+      '';
+      description = ''
+        List of webhooks to set up on the server, such as 
+        [UnifiedPush notifications](https://docs.bluebubbles.app/client/usage-guides/using-unified-push-for-notifications).  
+        To configure webhooks through Nix, the password must also be set through Nix 
+        ({option}`secretFiles.password`), 
+        as webhooks are managed through authenticated cURLs to the REST API.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !(cfg.secretFiles.password == null && cfg.webhooks != []);
+        message = ''
+          For webhooks to be Nix-managed, you must also set the password ({option}`secretFiles.password`) 
+          through Nix, as webhooks are set up through authenticated cURLs to the REST API.
+        '';
+      }
+    ];
+    warnings = mkIf (cfg.webhooks != [] && cfg.settings.socket_port == null) [
+      ''
+        Webhooks are set up through the REST API. As {option}`settings.socket_port` is not set, 
+        it is assumed the server is running on the default port (1234); if this has been changed 
+        imperatively/externally, webhook setup will fail. 
+        Explicitly set the port to suppress this warning.
+      ''
+    ];
+
+    environment.systemPackages = [ cfg.package ];
+
+    system.requiresPrimaryUser = [ "services.bluebubbles-server.enable" ];
+
+    launchd.user.agents = {
+      bluebubbles-server = {
+        script = ''
+          exec ${cfg.package}/${exePath} ${concatStringsSep " "
+            ((
+              mapAttrsToList 
+              (k: v: 
+                "--${k} \"${if builtins.isBool v
+                  then (
+                    # Bools by default stringify to "0"/"1"
+                    if v
+                    then "true"
+                    else "false"
+                  )
+                  else toString v
+                }\"") 
+              (lib.filterAttrs (_: v: v != null) cfg.settings)
+            ) ++ 
+            ( 
+              # script executed in stdenv.shell (bash), so we can use `$(<file)` (else would need cat/read)
+              # to read file contents at runtime & avoid adding secrets to the store
+              # Do something to trim whitespace? 
+              mapAttrsToList
+              (k: v: "--${k} \"$(<\"${v}\")\"")
+              (lib.filterAttrs (_: v: v != null) cfg.secretFiles)
+            ))}
+        '';
+        serviceConfig = let 
+          label = "server"; 
+        in {
+          KeepAlive = true;
+          RunAtLoad = true;
+          Label = "${agentPrefix}.${label}";
+          StandardErrorPath = "${config.system.primaryUserHome}/${logDir}/${label}.log";
+          StandardOutPath = "${config.system.primaryUserHome}/${logDir}/${label}.log";
+          ProcessType = "Interactive"; # do not throttle
+        };
+      };
+
+      bluebubbles-set-webhooks = mkIf (cfg.webhooks != []) {
+        # while there is no direct way to declaratively specify webhooks, there are undocumented REST API endpoints 
+        # cf. https://github.com/BlueBubblesApp/bluebubbles-server/blob/95204ac18513fffcbb76cafed26008952e8346b3/packages/server/src/server/api/http/api/v1/httpRoutes.ts#L666-L687
+        # list webhooks  = GET    api/v1/webhook
+        # create webhook = POST   api/v1/webhook
+        # delete webhook = DELETE api/v1/webhook/{id}
+        # ping = GET api/v1/ping
+        # for all of these, must be authenticated with the server password, by passing as param (guid, password, or token; all aliases)
+        # so, to setup webhooks, we cURL the endpoints, first getting the existing webhooks, deleting them, and creating new ones
+        script = let
+          jq = "${pkgs.jq}/bin/jq";
+          curl = "${pkgs.curl}/bin/curl";
+          lockFile = "${config.system.primaryUserHome}/${lockPath}";
+        in
+          ''
+          set -euo pipefail
+
+          log() {
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" >&2
+          }
+
+          call_api() {
+            local method="$1"
+            local endpoint="$2"
+            local data="$3"
+
+            local url="http://127.0.0.1:${
+              if cfg.settings.socket_port != null 
+              then toString cfg.settings.socket_port 
+              else "1234"
+            }/api/v1/''${endpoint}?password=$(<"${cfg.secretFiles.password}")"
+
+
+            if [ -n "$data" ]; then
+              ${curl} -s -X "$method" "$url" \
+                -H "Content-Type: application/json" \
+                -d "$data"
+            else
+              ${curl} -s -X "$method" "$url"
+            fi
+          }
+
+          get_webhooks() {
+            local response=$(call_api "GET" "webhook" "")
+            local status=$(echo "$response" | ${jq} '.status')
+            if [ "$status" -ne 200 ]; then
+              log "Failed to fetch webhooks: $($response | ${jq})"
+              exit 1
+            fi
+            echo "$response" 
+          }
+          get_webhook_ids() {
+            get_webhooks | ${jq} -c '.data[].id'
+          }
+          delete_webhook() {
+            call_api "DELETE" "webhook/$1" "" | ${jq} '.status'
+          }
+          create_webhook() {
+            call_api "POST" "webhook" "$1" | ${jq} '.status'
+          }
+          ping_api() {
+            call_api "GET" "ping" "" | ${jq} '.status'
+          }
+
+
+          # if triggered by lockfile disappearance, rather than creation, quit
+          # if [ ! -e "${lockFile}" ]; then
+          #  log "Lockfile missing, exiting."
+          #  exit 0;
+          #fi
+
+          # else, server just started, wait for the ping to return OK
+          log "Server running, waiting for API to be ready..."
+
+          MAX_RETRIES=30
+          RETRY_DELAY=2
+          RETRIES=0
+          while [ $RETRIES -lt $MAX_RETRIES ]; do
+            status=$(ping_api)
+            if [ $status -eq 200 ]; then
+              log "Server is ready!"
+              break
+            fi
+            log "Waiting for server... (attempt $((RETRIES + 1))/$MAX_RETRIES)"
+            sleep $RETRY_DELAY
+            RETRIES=$((RETRIES + 1))
+          done
+          
+          if [ $RETRIES -eq $MAX_RETRIES ]; then
+            log "Server failed to become ready after $MAX_RETRIES attempts"
+            exit 1
+          fi
+          
+          log "Cleaning up existing webhooks..."
+          get_webhook_ids | while read -r ID; do
+            if [ -n "$ID" ]; then
+              log "Deleting webhook $ID"
+              if [ $(delete_webhook "$ID") -ne 200 ]; then
+                log "Failed to delete webhook $ID"
+                exit 1
+              fi
+            fi
+          done
+          
+          ${lib.concatMapStringsSep "\n" (webhook: ''
+            log "Creating webhook for \"${webhook.url}\"..."
+            if [ $(create_webhook '${builtins.toJSON webhook}') -ne 200 ]; then
+              log "Failed to create webhook for \"${webhook.url}\""
+              exit 1
+            fi
+          '') cfg.webhooks}
+
+          log "Setup complete. Webhooks: $(get_webhooks | ${jq} '.data')"
+        '';
+        serviceConfig = let 
+          label = "set-webhooks";
+        in {
+          # lockfile present while bluebubbles-server is running
+          WatchPaths = [ "${config.system.primaryUserHome}/${lockPath}" ];
+          RunAtLoad = true;
+          Label = "${agentPrefix}.${label}";
+          StandardErrorPath = "${config.system.primaryUserHome}/${logDir}/${label}.log";
+          StandardOutPath = "${config.system.primaryUserHome}/${logDir}/${label}.log";
+        };
+      };
+
+    };
+
+  };
+
+  meta.maintainers = [
+    maintainers.zacharyweiss or "zacharyweiss"
+  ];
+}

--- a/modules/services/bluebubbles-server/settings.nix
+++ b/modules/services/bluebubbles-server/settings.nix
@@ -1,0 +1,199 @@
+{ lib, pkgs, ... }:
+with lib;
+let 
+  mkNullOpt = type: description: mkOption {
+    type = types.nullOr type; 
+    default = null; 
+    inherit description;
+  };
+
+  # directly shadows the keys of upstream config options.
+  # anything left null falls back to upstream defaults,
+  # specified in https://github.com/BlueBubblesApp/bluebubbles-server/blob/9ee91200121888ed9dbe300dfccf8e6d2a8592d2/packages/server/src/server/databases/server/constants.ts#L18-L59
+  # descriptions copied from UI field hints, where available: https://github.com/BlueBubblesApp/bluebubbles-server/tree/9ee91200121888ed9dbe300dfccf8e6d2a8592d2/packages/ui/src/app/components/fields
+  # only settings omitted here are secrets; cf. `secretFiles` option
+  settingsModule.options = {
+    tutorial_is_done = mkNullOpt types.bool "Set to `true` to skip the tutorial";
+    socket_port = mkNullOpt types.port "This is the port that the HTTP server is running on, and the port you will use when port forwarding for a dynamic DNS";
+    # password = mkNullSecret "Path to password for clients to authenticate with the server";
+
+    proxy_service = mkNullOpt (types.enum [
+      "cloudflare" "dynamic-dns" "ngrok" "zrok" "lan-url"
+    ]) "Select a proxy service to use to make your server internet-accessible. Without one selected, your server will only be accessible on your local network";
+
+    ## proxy-service = "dynamic-dns"
+    server_address = mkNullOpt types.str "This is the address that your clients will connect to";
+
+    ## proxy-service = "ngrok"
+    #ngrok_key = mkNullOpt types.path ''
+    #  Using an Auth Token will allow you to use the benefits of the upgraded Ngrok
+    #  service. This can improve connection stability and reliability. It is highly
+    #  recommended that you setup an auth token, especially if you are having connection
+    #  issues. If you do not have an Ngrok Account, sign up for free here:
+    #  https://dashboard.ngrok.com/get-started/your-authtoken
+    #'';
+    ngrok_protocol = mkNullOpt types.str "";
+    ngrok_region = mkNullOpt (types.enum ["us" "eu" "ap" "au" "sa" "jp" "in"]) ''
+      Select the region closest to you. This will ensure latency is at its lowest when connecting to the server
+    '';
+    ngrok_custom_domain = mkNullOpt types.str ''
+      On the Ngrok website, you can reserve a subdomain with Ngrok. This allows
+      your URL to stay static, and never change. This may improve connectivity
+      reliability. To reserve your domain today, go to the following link
+      and create a new subdomain. Then copy and paste it into this field:
+      https://dashboard.ngrok.com/cloud-edge/domains
+    '';
+
+    ## proxy-service = "zrok"
+    #zrok_token = mkNullOpt types.path ''
+    #  A Zrok Token is required to use the Zrok proxy service. If you do not have one, you can sign up for a free account within BlueBubbles
+    #'';
+    zrok_reserve_tunnel = mkNullOpt types.bool ''
+      Enabling this will create a reserved tunnel with Zrok.
+      This means your Zrok URL will be static and never change
+    '';
+    zrok_reserved_name = mkNullOpt types.str ''
+      Reserved Subdomain (Optional): Enter a name to reserve for your Zrok tunnel.
+      This name will be used as the subdomain for your Zrok tunnel.
+      This name may only be lowercase alpha-numeric characters. If
+      left blank, a randomly generated name will be used.
+    '';
+    # zrok_reserved_token = mkNullOpt types.path ""; # ??
+
+
+    use_custom_certificate = mkNullOpt types.bool ''
+      This will install a self-signed certificate at: `~/Library/Application Support/bluebubbles-server/Certs`
+      Note: Only use this option if you have your own certificate! 
+      Replace the certificates in the `Certs` directory
+    '';
+    auto_caffeinate = mkNullOpt types.bool ''
+      When enabled, your Mac will not fall asleep due to inactivity or a screen screen saver.
+      However, your computer lid's close action may override this.
+      Make sure your computer does not go to sleep when the lid is closed.
+    '';
+
+    hide_dock_icon = mkNullOpt types.bool ''Hiding the dock icon will not close the app. You can open the app again via the status bar icon'';
+    dock_badge = mkNullOpt types.bool "Disable this to hide the notifications badge in the dock";
+
+    check_for_updates = mkNullOpt types.bool "When enabled, BlueBubbles will automatically check for updates on startup";
+    enable_private_api = mkNullOpt types.bool "If you have set up the Private API features, enable this option to allow the server to comunicate with the iMessage Private APIs. This will run an instance of the Messages app with our helper dylib injected into it. Enabling this will allow you to send reactions, replies, editing, effects, use FindMy, etc.";
+    enable_ft_private_api = mkNullOpt types.bool "If you have set up the Private API features, enabling this option will allow the server to communicate with the FaceTime Private APIs. This will run an instance of the FaceTime app with our helper dylib injected into it. Enabling this will allow the server to detect incoming FaceTime calls";
+    use_oled_dark_mode = mkNullOpt types.bool "Enabling this will set the dark mode theme to OLED black";
+    db_poll_interval = mkNullOpt types.ints.positive "Enter how often (in milliseconds) you want the server to check for new messages in the database";
+
+    private_api_mode = mkNullOpt (types.enum ["process-dylib" "macforge"]) ''
+      Select how you want the BlueBubbles Private API Helper Bundle to be injected into the Messages App. 
+      Selecting "MacForge Bundle" will require MacForge to be installed. Selecting "Messages App DYLIB" will 
+      attempt to inject the bundle into the Messages App directly.
+    '';
+    start_delay = mkNullOpt types.str "Enter the number of seconds to delay the server start by. This is useful on older hardware";
+    start_minimized = mkNullOpt types.bool "When enabled, the BlueBubbles Server will be minimized after starting up";
+    facetime_calling = mkNullOpt types.bool "(Experimental) When enabled, the server will detect incoming FaceTime calls and forward a notification to your device. If you choose to answer the call from the notification, the server will attempt to generate a link for you to join with";
+
+    landing_page_path = mkNullOpt types.path "Path to custom landing page HTML";
+    open_findmy_on_startup = mkNullOpt types.bool ''
+      When enabled, BlueBubbles will automatically open, then hide the FindMy app when the server starts.
+      This is to trigger the fetch of locations from the FindMy app so the server can cache them for clients.
+    '';
+    auto_lock_mac = mkNullOpt types.bool ''
+      When enabled, your Mac will be automatically locked when the BlueBubbles Server detects that it has just booted up.
+      The criteria for this is that the uptime for your Mac is less than 5 minutes.
+    '';
+
+    ## App tray settings. No upstream helptext; descriptions mine.
+    headless = mkNullOpt types.bool ''
+      Suppresses window creation at launch. App still requires a logged-in user session 
+      (cannot be daemonized), and  (depending on other settings) may open other windows 
+      (e.g. FindMy, Messages, FaceTime) to inject custom dylibs / force updates.
+    ''; 
+
+    ## hidden / unavailable in UI
+    ## including with {visible = false;} for completeness, 
+    ## despite being unfinished / not intended for config by users
+    encrypt_coms = mkOption {
+      default = null;
+      visible = false;
+      type = types.nullOr types.bool;
+      # From unused UI module field hint / help text
+      description = ''
+        Enabling this will add an additional layer of security to the app communications by encrypting messages with a password-based AES-256-bit algorithm
+      '';
+    };
+    last_fcm_restart = mkOption {
+      default = null;
+      visible = false;
+      type = types.nullOr types.str;
+      # Wholly undocumented upstream; text below _de moi_
+      description = ''
+        Last restart date of FCM; cf. `packages/server/src/server/services/fcmService/index.ts`
+      '';
+    };
+
+
+    ## required default settings for compatibility with Nix / nix-darwin module
+    ## (hence: { visible = false; internal = true; })
+    auto_start = mkOption {
+      # by virtue of the module being enabled, we want to auto-start
+      # but this is controlled by Nix (a Nix-managed LaunchAgent),
+      # not the application itself, hence, default = false;
+      default = false;
+      internal = true;
+      visible = false;
+      type = types.nullOr types.bool;
+      description = ''
+        When enabled, BlueBubbles will start automatically when you login to your computer.
+      '';
+    };
+    auto_start_method = mkOption {
+      # for same reason above, default to "unset"
+      default = "unset";
+      internal = true;
+      visible = false;
+      type = types.nullOr (types.enum [
+        "none" "unset" "login-item" "launch-agent"
+      ]);
+      description = ''
+        Select whether you want the BlueBubbles Server to automatically start when you login to your computer.
+        The "Launch Agent" option will let BlueBubbles restart itself, even after a hard crash. If you try to
+        switch away from the "Launch Agent" method, the server may automatically close itself.
+      '';
+    };
+    auto_install_updates = mkOption {
+      # updates are managed by Nix
+      default = false;
+      internal = true;
+      visible = false;
+      type = types.nullOr types.bool;
+      description = ''
+        When enabled, BlueBubbles will auto-install the latest available version when an update is detected
+      '';
+    };
+    start_via_terminal = mkOption {
+      # app should always be being launched by the LaunchAgent, never through the GUI
+      # further, this kind of fork-and-kill is likely to cause issues with LaunchAgents, as to the
+      # agent it will appear as though the process has died and needs to be restarted.
+      default = false;
+      internal = true;
+      visible = false;
+      type = types.nullOr types.bool;
+      description = ''
+        When BlueBubbles starts up, it will auto-reload itself in terminal mode.
+        When in terminal, type "help" for command information.
+      '';
+    };
+    disable_gpu = mkOption {
+      # https://github.com/BlueBubblesApp/bluebubbles-server/issues/726
+      # must be disabled when running as a LaunchAgent
+      default = false;
+      internal = true;
+      visible = false;
+      type = types.nullOr types.bool;
+      description = ''
+        "[A]dds flags to the executable to disable gpu utilization through electron"; 
+        conflicts with running as a LaunchAgent
+      '';
+    };
+  };
+in {
+  inherit settingsModule;
+}


### PR DESCRIPTION
[BlueBubbles](https://bluebubbles.app/) is an iMessage bridge. The client app was recently added to nixpkgs (https://github.com/NixOS/nixpkgs/pull/404147), and the PR for the server package (the dependency for this module) is pending in https://github.com/NixOS/nixpkgs/pull/414528. There's a few specific areas on which I'd appreciate the input of more experienced contributors / Darwin-ers  (hence the initial draft status). This is my first time writing a module for consumption by others; please be ruthless in your feedback so I can improve. (Sorry for the following wall of text!)

### Entitlements / security requirements
- For basic operation, it requires 
  - Full Disk Access (to read from the iMessages DB), 
  - [Contacts, automation, & other entitlements](https://github.com/BlueBubblesApp/bluebubbles-server/blob/95204ac18513fffcbb76cafed26008952e8346b3/packages/server/scripts/entitlements.mac.plist)
  - (Optionally) Accessibility: `Settings > Privacy & Security > Accessibility > (enable)`
- For full use of the private API features, it injects dylibs into Messages/FaceTime/etc, and as such requires:
  - Disabled library validation `sudo defaults write /Library/Preferences/com.apple.security.libraryvalidation.plist DisableLibraryValidation -bool true`
  - (Partially) [disabled SIP](https://docs.bluebubbles.app/private-api/installation): 0x807 

What's the best way to handle these? Leave for the user to manage imperatively when prompted for access? Some way to configure appropriately during an activation script? For items we can't manage through Nix (e.g., SIP), add an activation script that checks status and warns/errors?

### Secrets
Upstream, config is assumed to occur through the GUI. There is, however, the undocumented ability to configure the service through CLI args or a config file at `~/bluebubbles.yml`; I've opted for the former in writing this module. While there isn't passwordFile support, I've emulated a passwordFile approach by passing secrets as `--secret-var "$(<"/path/to/secretFile")"` in the LaunchAgent script. Is this appropriate / sufficiently secure? Unfortunately, as (I believe; need to confirm) the service must run as the user, the secrets must be readable/owned by the user as well.

### Settings
Presently, I shadow/mirror the upstream settings directly (with only a few hidden & pre-set for compatibility with launchd). While this represents the full set of available options currently, this could be a moving target. Should I include some method to pass additional arguments directly (eg, a string / concat-ed strings that get appended to the end of the exe call)?

### LaunchAgents: dependencies, daemonization, & stateful-ness
While webhooks (used primarily for UnifiedPush notifications) are not included in the set of declarative options they accept, there are REST endpoints for getting/setting/deleting them; to add declarative support I've written a secondary LaunchAgent that cURLs these endpoints to set them up.

- Initially I sought to use `serviceConfig.WatchPaths` and the SingletonLock the service itself links while running as a trigger for the webhook-setting Agent, and ignoring "falling-edge" signals (if triggered by lockfile disappearance rather than creation, quit), but it seems a race condition can occur when both the primary agent and the webhook-setting one are started simultaneously. Currently I just have it `RunAtLoad` and repeatedly query the "ping" endpoint until I get status 200; is there a better way to make dependencies between LaunchAgents explicit, and/or make failures flow back to Nix for the sake of auto-rollbacks / warnings / etc?
- The requests must be authenticated using the server password; if webhooks are Nix-managed, the password must be too. For folks who don't want to manage the password declaratively, I wrapped the agent in a mkIf, conditional on there being webhooks to set. However, this will miss the case of one setting webhooks, and then later removing all; the Agent won't be made and the hooks won't be cleaned up. What's the most appropriate way to handle this statefulness?
- Ideally, the service would run as a LaunchDaemon so as not to require log-in. However, conditional on some of the settings (e.g. the Private APIs, FindMy), it wants to launch other graphical apps to trigger updates, inject custom dylibs, etc, and further, (I believe) it must run as/on-behalf-of the user for whom we're bridging messages. Is there a way this can be adapted to the `system` domain? Or must it live under `gui/{id}` as a LaunchAgent?

### Misc
- Any stylistic, formatting, or organization changes that ought to be made?
- If the Agent(s) cannot be made Daemon(s), and the security settings are left imperative / are not Nix-manageable, is this better suited as a home-manager module? I started writing it as a darwin module under the assumption that it would act as a Daemon and/or need system-level security settings (along with the fact that this is only for darwin targets), but if everything is in the user domain, I'm not sure if it fails some inclusion criteria for nix-darwin