### PR TITLE
networking.applicationFirewall: init

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -49,6 +49,7 @@
   ./system/version.nix
   ./time
   ./networking
+  ./networking/applicationFirewall.nix
   ./nix
   ./nix/linux-builder.nix
   ./nix/nix-darwin.nix

--- a/modules/networking/applicationFirewall.nix
+++ b/modules/networking/applicationFirewall.nix
@@ -1,0 +1,48 @@
+{ config, lib, ... }:
+let
+  cfg = config.networking.applicationFirewall;
+
+  socketfilterfw =
+    option: value:
+    lib.concatStringsSep " " [
+      "/usr/libexec/ApplicationFirewall/socketfilterfw"
+      "--${option}"
+      (if value then "on" else "off")
+    ];
+in
+{
+  meta.maintainers = [
+    (lib.maintainers.prince213 or "prince213")
+  ];
+
+  options.networking.applicationFirewall = {
+    enable = lib.mkOption {
+      type = lib.types.nullOr lib.types.bool;
+      default = null;
+      example = true;
+      description = "Whether to enable application firewall.";
+    };
+    blockAllIncoming = lib.mkEnableOption "blocking all incoming connections";
+    allowSigned = lib.mkEnableOption "built-in software to receive incoming connections" // {
+      default = true;
+    };
+    allowSignedApp =
+      lib.mkEnableOption "downloaded signed software to receive incoming connections"
+      // {
+        default = true;
+      };
+    enableStealthMode = lib.mkEnableOption "stealth mode";
+  };
+
+  config = {
+    system.activationScripts.networking.text = ''
+      echo "configuring application firewall..." >&2
+
+      ${lib.optionalString (cfg.enable != null) (socketfilterfw "setglobalstate" cfg.enable)}
+      ${lib.optionalString (cfg.enable == true) (socketfilterfw "setblockall" cfg.blockAllIncoming)}
+      ${socketfilterfw "setallowsigned" cfg.allowSigned}
+      ${socketfilterfw "setallowsignedapp" cfg.allowSignedApp}
+      ${socketfilterfw "setstealthmode" cfg.enableStealthMode}
+    '';
+  };
+}

--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -20,7 +20,6 @@ let
   dockFiltered = (builtins.removeAttrs cfg.dock ["expose-group-by-app"]);
 
   # defaults
-  alf = defaultsToList "/Library/Preferences/com.apple.alf" cfg.alf;
   loginwindow = defaultsToList "/Library/Preferences/com.apple.loginwindow" cfg.loginwindow;
   smb = defaultsToList "/Library/Preferences/SystemConfiguration/com.apple.smb.server" cfg.smb;
   SoftwareUpdate = defaultsToList "/Library/Preferences/com.apple.SoftwareUpdate" cfg.SoftwareUpdate;
@@ -89,7 +88,6 @@ in
       ];
 
     system.activationScripts.defaults.text = mkIfLists [
-      alf
       loginwindow
       smb
       SoftwareUpdate
@@ -98,7 +96,6 @@ in
       ''
         # Set defaults
         echo >&2 "system defaults..."
-        ${concatStringsSep "\n" alf}
         ${concatStringsSep "\n" loginwindow}
         ${concatStringsSep "\n" smb}
         ${concatStringsSep "\n" SoftwareUpdate}

--- a/modules/system/defaults/alf.nix
+++ b/modules/system/defaults/alf.nix
@@ -1,74 +1,26 @@
-{ config, lib, ... }:
+{ lib, ... }:
 
-with lib;
-
+let
+  path = [
+    "system"
+    "defaults"
+    "alf"
+  ];
+in
 {
-  options = {
-    system.defaults.alf.globalstate = mkOption {
-      type = types.nullOr types.int;
-      default = null;
-      description = ''
-        Apple menu > System Preferences > Security and Privacy > Firewall
-
-        Enable the internal firewall to prevent unauthorised applications, programs
-        and services from accepting incoming connections.
-
-        0 = disabled
-        1 = enabled
-        2 = blocks all connections except for essential services
-      '';
-    };
-
-    system.defaults.alf.allowsignedenabled = mkOption {
-      type = types.nullOr types.int;
-      default = null;
-      description = ''
-        Apple menu > System Preferences > Security and Privacy > Firewall
-
-        Allows any signed Application to accept incoming requests. Default is true.
-
-        0 = disabled
-        1 = enabled
-      '';
-    };
-
-    system.defaults.alf.allowdownloadsignedenabled = mkOption {
-      type = types.nullOr types.int;
-      default = null;
-      description = ''
-        Apple menu > System Preferences > Security and Privacy > Firewall
-
-        Allows any downloaded Application that has been signed to accept incoming requests. Default is 0.
-
-        0 = disabled
-        1 = enabled
-      '';
-    };
-
-    system.defaults.alf.loggingenabled = mkOption {
-      type = types.nullOr types.int;
-      default = null;
-      description = ''
-        Apple menu > System Preferences > Security and Privacy > Firewall
-
-        Enable logging of requests made to the firewall. Default is 0.
-
-        0 = disabled
-        1 = enabled
-      '';
-    };
-
-    system.defaults.alf.stealthenabled = mkOption {
-      type = types.nullOr types.int;
-      default = null;
-      description = ''
-        Apple menu > System Preferences > Security and firewall
-
-        Drops incoming requests via ICMP such as ping requests. Default is 0.
-
-        0 = disabled
-        1 = enabled
-      '';
-    };
-  };
+  imports = [
+    (lib.mkRemovedOptionModule (path ++ [ "globalstate" ])
+      "Use `networking.applicationFirewall.enable' and `networking.applicationFirewall.blockAllIncoming' instead."
+    )
+    (lib.mkRemovedOptionModule (
+      path ++ [ "allowsignedenabled" ]
+    ) "Use `networking.applicationFirewall.allowSigned' instead.")
+    (lib.mkRemovedOptionModule (
+      path ++ [ "allowdownloadsignedenabled" ]
+    ) "Use `networking.applicationFirewall.allowSignedApp' instead.")
+    (lib.mkRemovedOptionModule (path ++ [ "loggingenabled" ]) "It's no longer necessary.")
+    (lib.mkRemovedOptionModule (
+      path ++ [ "stealthenabled" ]
+    ) "Use `networking.applicationFirewall.enableStealthMode' instead.")
+  ];
 }


### PR DESCRIPTION
This PR adds a new module `networking.applicationFirewall` for configuring the Application Layer Firewall.