### PR TITLE
services/ntpd-rs: init

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -87,6 +87,7 @@
   ./services/nix-daemon.nix
   ./services/nix-gc
   ./services/nix-optimise
+  ./services/ntpd-rs.nix
   ./services/ofborg
   ./services/openssh.nix
   ./services/postgresql

--- a/modules/services/ntpd-rs.nix
+++ b/modules/services/ntpd-rs.nix
@@ -1,0 +1,62 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.ntpd-rs;
+  format = pkgs.formats.toml { };
+  configFile = format.generate "ntpd-rs.toml" cfg.settings;
+in
+{
+  options.services.ntpd-rs = {
+    enable = lib.mkEnableOption "Network Time Service (ntpd-rs)";
+    metrics.enable = lib.mkEnableOption "ntpd-rs Prometheus Metrics Exporter";
+
+    package = lib.mkPackageOption pkgs "ntpd-rs" { };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = format.type;
+      };
+      default = { };
+      description = ''
+        Settings to write to {file}`ntp.toml`
+
+        See <https://docs.ntpd-rs.pendulum-project.org/man/ntp.toml.5>
+        for more information about available options.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    services.ntpd-rs.settings = {
+      observability = {
+        observation-path = lib.mkDefault "/var/run/ntpd-rs/observe";
+      };
+    };
+
+    launchd.daemons.ntpd-rs = {
+      script = ''
+        mkdir -p "$(dirname ${cfg.settings.observability.observation-path})"
+        exec ${lib.getExe' cfg.package "ntp-daemon"} --config=${configFile}
+      '';
+      environment.USER = "root";
+      serviceConfig.KeepAlive = true;
+      serviceConfig.RunAtLoad = true;
+    };
+
+    launchd.daemons.ntpd-rs-metrics = lib.mkIf cfg.metrics.enable {
+      script = ''
+        exec ${lib.getExe' cfg.package "ntp-metrics-exporter"} --config=${configFile}
+      '';
+      environment.USER = "root";
+      serviceConfig.KeepAlive = true;
+      serviceConfig.RunAtLoad = true;
+    };
+  };
+}

--- a/release.nix
+++ b/release.nix
@@ -109,6 +109,7 @@ in {
   tests.services-nix-optimise = makeTest ./tests/services-nix-optimise.nix;
   tests.services-nextdns = makeTest ./tests/services-nextdns.nix;
   tests.services-netdata = makeTest ./tests/services-netdata.nix;
+  tests.services-ntpd-rs = makeTest ./tests/services-ntpd-rs.nix;
   tests.services-ofborg = makeTest ./tests/services-ofborg.nix;
   tests.services-offlineimap = makeTest ./tests/services-offlineimap.nix;
   tests.services-openssh = makeTest ./tests/services-openssh.nix;

--- a/tests/services-ntpd-rs.nix
+++ b/tests/services-ntpd-rs.nix
@@ -1,0 +1,13 @@
+{
+  config,
+  ...
+}:
+
+{
+  services.ntpd-rs.enable = true;
+
+  test = ''
+    echo >&2 "checking ntpd-rs service in ~/Library/LaunchDaemons"
+    grep "org.nixos.ntpd-rs" ${config.out}/Library/LaunchDaemons/org.nixos.ntpd-rs.plist
+  '';
+}


### PR DESCRIPTION
Related: https://github.com/ngi-nix/ngipkgs/issues/891

Port [ntpd-rs nixos option](https://search.nixos.org/options?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=services.ntpd-rs) to nix-darwin