### PR TITLE
fix: restart Dock with `killall` without linux only `-q` option

### DIFF
--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -153,7 +153,7 @@ in
 
         ${optionalString (length dock > 0) ''
           echo >&2 "restarting Dock..."
-          killall -qu ${escapeShellArg config.system.primaryUser} Dock || true
+          killall -u ${escapeShellArg config.system.primaryUser} Dock || true
         ''}
       '';
 


### PR DESCRIPTION
Fixes: https://github.com/nix-darwin/nix-darwin/issues/1524