### PR TITLE
github-runner/service.nix: fix missing argument in workDir assertion

### DIFF
--- a/modules/services/github-runner/service.nix
+++ b/modules/services/github-runner/service.nix
@@ -27,7 +27,7 @@ in
         message = "`services.github-runners.${name}`: The `extraLabels` option is mandatory if `noDefaultLabels` is set";
       }
       {
-        assertion = cfg.workDir == null || !(hasPrefix "/run/" cfg.workDir || hasPrefix "/var/run/" cfg.workDir || hasPrefix "/private/var/run/");
+        assertion = cfg.workDir == null || !(hasPrefix "/run/" cfg.workDir || hasPrefix "/var/run/" cfg.workDir || hasPrefix "/private/var/run/" cfg.workDir);
         message = "`services.github-runners.${name}`: `workDir` being inside /run is not supported";
       }
     ])


### PR DESCRIPTION
There's a typo here that was making `workDir` impossible to set to a string.