### PR TITLE
darwin-rebuild: use pkgs.nix for the flake packages output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,9 @@
     };
 
     overlays.default = final: prev: {
-      inherit (prev.callPackage ./pkgs/nix-tools { }) darwin-rebuild darwin-option darwin-version;
+      inherit (prev.callPackage ./pkgs/nix-tools {
+        nixPackage = prev.nix;
+      }) darwin-rebuild darwin-option darwin-version;
 
       darwin-uninstaller = prev.callPackage ./pkgs/darwin-uninstaller { };
     };


### PR DESCRIPTION
Nix-darwin flake's `packages.${system}.darwin-rebuild` currently uses `null` for `nixPackage`, this leads to the script to use `/var/root/.nix-profile/bin/nix` since it insists on running as root.

I'm not sure why, but on my Mac that file points to an old version of nix, which lacks support for `inputs.self.submodule` for example.

I'm also not sure if this is the right fix, but it's the most direct one.