### PR TITLE
add `escape = true` to `toPlist` calls

### DIFF
--- a/modules/launchd/default.nix
+++ b/modules/launchd/default.nix
@@ -9,7 +9,7 @@ let
 
   toEnvironmentText = name: value: {
     name = "${value.serviceConfig.Label}.plist";
-    value.text = generators.toPlist { } value.serviceConfig;
+    value.text = generators.toPlist { escape = true; } value.serviceConfig;
   };
 
   launchdConfig = import ./launchd.nix;

--- a/modules/system/defaults-write.nix
+++ b/modules/system/defaults-write.nix
@@ -6,7 +6,7 @@ let
   cfg = config.system.defaults;
 
   writeDefault = domain: key: value:
-    "defaults write ${domain} '${key}' $'${strings.escape [ "'" ] (generators.toPlist { } value)}'";
+    "defaults write ${domain} '${key}' $'${generators.toPlist { escape = true; } value}'";
 
   defaultsToList = domain: attrs: mapAttrsToList (writeDefault domain) (filterAttrs (n: v: v != null) attrs);
   userDefaultsToList = domain: attrs: let


### PR DESCRIPTION
Closes #1564.
In `modules/system/defaults-write.nix`, I also removed the part that escapes single quotes, as `toPlist` with `escape = true` will handle single quote escaping. See `escapeXML` in `lib.strings`

https://github.com/NixOS/nixpkgs/blob/10079aa8ba7b1ecb2024b7fb487232281137dfeb/lib/strings.nix#L1435-L1438