### PR TITLE
services.netbird: add support for multiple clients

### DIFF
--- a/modules/services/netbird.nix
+++ b/modules/services/netbird.nix
@@ -1,35 +1,319 @@
 { config, lib, pkgs, ... }:
+
 with lib;
+
 let
   cfg = config.services.netbird;
+
+  # Helper functions for common paths and configurations
+  getClientPaths = clientName: {
+    configDir = "/var/lib/netbird-${clientName}";
+    configFile = "/var/lib/netbird-${clientName}/config.json";
+    configDirEtc = "/etc/netbird-${clientName}/config.d";
+    runtimeDir = "/var/run/netbird-${clientName}";
+    socketAddr = "unix:///var/run/netbird-${clientName}.sock";
+    logOut = "/var/log/netbird-${clientName}.out.log";
+    logErr = "/var/log/netbird-${clientName}.err.log";
+  };
+
+  getClientEnvVars = clientCfg: let
+    paths = getClientPaths clientCfg.name;
+  in {
+    NB_CONFIG = paths.configFile;
+    NB_LOG_FILE = "console";
+    NB_DAEMON_ADDR = paths.socketAddr;
+    NB_INTERFACE_NAME = clientCfg.interface;
+    NB_WIREGUARD_PORT = toString clientCfg.port;
+    NB_LOG_LEVEL = clientCfg.logLevel;
+  };
+
+  getDefaultEnvVars = {
+    NB_CONFIG = "/var/lib/netbird/config.json";
+    NB_LOG_FILE = "console";
+  };
+
+  # Generate helper script for a client
+  mkClientScript = clientCfg:
+    pkgs.writeScriptBin "netbird-${clientCfg.name}" ''
+      #!${pkgs.bash}/bin/bash
+      # Helper script for ${clientCfg.name} NetBird instance
+      export NB_CONFIG="${(getClientPaths clientCfg.name).configFile}"
+      export NB_DAEMON_ADDR="${(getClientPaths clientCfg.name).socketAddr}"
+      export NB_INTERFACE_NAME="${clientCfg.interface}"
+      export NB_WIREGUARD_PORT="${toString clientCfg.port}"
+      export NB_LOG_FILE="console"
+      export NB_LOG_LEVEL="${clientCfg.logLevel}"
+      export NB_SERVICE="netbird-${clientCfg.name}"
+      exec ${clientCfg.package}/bin/netbird "$@"
+    '';
+
+  clientSubmodule = types.submodule (
+    { name, config, ... }:
+    let
+      client = config;
+    in
+    {
+      options = {
+        enable = mkEnableOption "this NetBird client instance" // { default = true; };
+        package = mkOption {
+          type = types.package;
+          default = pkgs.netbird;
+          defaultText = literalExpression "pkgs.netbird";
+          description = "The package to use for this NetBird instance.";
+        };
+        port = mkOption {
+          type = types.port;
+          example = literalExpression "51820";
+          description = "Port the NetBird client listens on.";
+        };
+        name = mkOption {
+          type = types.str;
+          default = name;
+          description = "Primary name for use as a suffix in service names, directories, and interfaces.";
+        };
+        interface = mkOption {
+          type = types.str;
+          default = "utun${toString (100 + (lib.lists.findFirstIndex (x: x == name) 0 (builtins.attrNames cfg.clients)))}";
+          description = "Name of the network interface managed by this client. Uses utun100+ prefix to avoid conflicts with system interfaces.";
+        };
+        config = mkOption {
+          type = (pkgs.formats.json { }).type;
+          defaultText = literalExpression ''
+            {
+              DisableAutoConnect = false;
+              WgIface = client.interface;
+              WgPort = client.port;
+            }
+          '';
+          description = "Additional configuration that exists before the first start and later overrides the existing values in config.json.";
+        };
+        autoStart = mkOption {
+          type = types.bool;
+          default = true;
+          description = "Start the service with the system.";
+        };
+        logLevel = mkOption {
+          type = types.enum [ "debug" "info" "warn" "error" ];
+          default = "info";
+          description = "Log level for this NetBird instance.";
+        };
+        group = mkOption {
+          type = types.str;
+          default = "daemon";
+          description = "Group to run the NetBird service under. The group will be created if it doesn't exist.";
+        };
+        openFirewall = mkOption {
+          type = types.bool;
+          default = true;
+          description = "Opens up firewall port for communication between NetBird peers directly over LAN or public IP.";
+        };
+        setupKeyFile = mkOption {
+          type = types.nullOr types.path;
+          default = null;
+          example = "/run/agenix/netbird-metacraft-setup-key";
+          description = ''
+            Path to a file containing this client's NetBird setup key, read at
+            runtime via `netbird up --setup-key-file`. Takes precedence over an
+            inline `config.SetupKey` and, unlike it, keeps the key out of the
+            world-readable Nix store. The file is produced out-of-band (e.g. by
+            agenix or sops-nix); this module only needs the path.
+          '';
+        };
+      };
+    }
+  );
 in
 {
   options.services.netbird = {
-    enable = mkEnableOption "Netbird daemon";
+    enable = mkEnableOption "NetBird daemon (default instance)" // { default = false; };
     package = mkOption {
       type = types.package;
       default = pkgs.netbird;
       defaultText = literalExpression "pkgs.netbird";
-      description = "The package to use for netbird";
+      description = "The package to use for the default NetBird instance.";
+    };
+    clients = mkOption {
+      type = types.attrsOf clientSubmodule;
+      default = {};
+      example = {
+        work = {
+          port = 13132;
+          logLevel = "debug";
+          group = "netbird";
+          config = {
+            SetupKey = "12345678-1234-1234-1234-123456789012";
+          };
+        };
+        home = {
+          port = 13133;
+          logLevel = "info";
+          group = "netbird";
+          config = {
+            SetupKey = "87654321-4321-4321-4321-210987654321";
+          };
+        };
+      };
+      description = "Attribute set of NetBird client instances.";
     };
   };
-  config = mkIf cfg.enable {
-    environment.systemPackages = [ cfg.package ];
-    launchd.daemons.netbird = {
-      script = ''
-        mkdir -p /var/run/netbird /var/lib/netbird
-        exec ${cfg.package}/bin/netbird service run
-      '';
-      serviceConfig = {
-        EnvironmentVariables = {
-          NB_CONFIG = "/var/lib/netbird/config.json";
-          NB_LOG_FILE = "console";
+
+  config = mkIf (cfg.enable || cfg.clients != {}) {
+    environment.systemPackages =
+      (optional cfg.enable cfg.package) ++
+      (mapAttrsToList (n: t: t.package) (filterAttrs (n: t: t.enable) cfg.clients)) ++
+      # Generate helper scripts for each client instance
+      (mapAttrsToList (name: clientCfg:
+        lib.optionalString clientCfg.enable (mkClientScript clientCfg)
+      ) cfg.clients);
+
+    # Create config directories and files for each client
+    environment.etc = mapAttrs' (name: clientCfg:
+      nameValuePair "netbird-${clientCfg.name}/config.d/50-nix-darwin.json" (
+        mkIf clientCfg.enable {
+          text = builtins.toJSON (clientCfg.config // {
+            WgIface = clientCfg.interface;
+            WgPort = clientCfg.port;
+          });
+        }
+      )
+    ) cfg.clients;
+
+    launchd.daemons =
+      (optionalAttrs cfg.enable {
+        netbird = {
+          script = ''
+            mkdir -p /var/run/netbird /var/lib/netbird
+            exec ${cfg.package}/bin/netbird service run
+          '';
+          serviceConfig = {
+            EnvironmentVariables = getDefaultEnvVars;
+            KeepAlive = true;
+            RunAtLoad = true;
+            StandardOutPath = "/var/log/netbird.out.log";
+            StandardErrorPath = "/var/log/netbird.err.log";
+          };
         };
-        KeepAlive = true;
-        RunAtLoad = true;
-        StandardOutPath = "/var/log/netbird.out.log";
-        StandardErrorPath = "/var/log/netbird.err.log";
-      };
-    };
+      }) //
+      (mapAttrs' (name: clientCfg: nameValuePair "netbird-${clientCfg.name}" (
+        mkIf clientCfg.enable (let
+          paths = getClientPaths clientCfg.name;
+          inlineSetupKey = clientCfg.config.SetupKey or "";
+          # Prefer a runtime key file (keeps the key out of the world-readable
+          # Nix store); fall back to an inline config.SetupKey. Only the path is
+          # embedded in the store; netbird reads the key from it at runtime.
+          loginCommand =
+            if clientCfg.setupKeyFile != null
+            then "${clientCfg.package}/bin/netbird up --setup-key-file ${lib.escapeShellArg (toString clientCfg.setupKeyFile)}"
+            else if inlineSetupKey != ""
+            then "${clientCfg.package}/bin/netbird up --setup-key ${lib.escapeShellArg inlineSetupKey}"
+            else null;
+        in {
+          script = ''
+            # Create necessary directories
+            mkdir -p ${paths.runtimeDir} ${paths.configDir} ${paths.configDirEtc}
+            
+            echo "Debug: Created directories for ${clientCfg.name}"
+            echo "Debug: Config file: ${paths.configFile}"
+            echo "Debug: Config.d directory: ${paths.configDirEtc}"
+            
+            # Initialize config.json if it doesn't exist
+            if [ ! -f ${paths.configFile} ]; then
+              echo '{}' > ${paths.configFile}
+              echo "Debug: Created empty config.json"
+            else
+              echo "Debug: Using existing config.json"
+            fi
+            
+            # Show what's in config.d
+            echo "Debug: Contents of config.d:"
+            ls -la ${paths.configDirEtc}/*.json 2>/dev/null || echo "Debug: No config.d files found"
+            
+            # Merge configuration files using jq (following NixOS pattern)
+            if command -v jq >/dev/null 2>&1; then
+              echo "Debug: jq found, attempting to merge configs"
+              # Create a temporary merged config
+              jq -sS 'reduce .[] as $i ({}; . * $i)' \
+                ${paths.configFile} \
+                ${paths.configDirEtc}/*.json \
+                > ${paths.configFile}.new 2>/dev/null || true
+              
+              # Update config if merge was successful
+              if [ -f ${paths.configFile}.new ] && [ -s ${paths.configFile}.new ]; then
+                mv ${paths.configFile}.new ${paths.configFile}
+                echo "Debug: Config merged successfully"
+              else
+                echo "Debug: Config merge failed or produced empty result"
+              fi
+            else
+              echo "Debug: jq not found, skipping config merge"
+            fi
+            
+            # Show final config content
+            echo "Debug: Final config.json content:"
+            cat ${paths.configFile}
+            
+            # Auto-login when a setup key is configured (a runtime key file or
+            # an inline key). loginCommand is null when neither is set.
+            if [ -n "${lib.optionalString (loginCommand != null) "1"}" ]; then
+              echo "Setup key configured, attempting automatic login..."
+              
+              # Start the service first
+              export NB_CONFIG=${paths.configFile}
+              export NB_DAEMON_ADDR=${paths.socketAddr}
+              export NB_INTERFACE_NAME=${clientCfg.interface}
+              export NB_WIREGUARD_PORT=${toString clientCfg.port}
+              export NB_LOG_LEVEL=${clientCfg.logLevel}
+              
+              ${clientCfg.package}/bin/netbird service run --config ${paths.configFile} &
+              SERVICE_PID=$!
+              
+              # Wait a moment for the service to start
+              sleep 2
+              
+              # Attempt automatic login (--setup-key-file if provided, else --setup-key)
+              echo "Attempting automatic login for ${clientCfg.name}..."
+              if ${loginCommand} 2>/dev/null; then
+                echo "Automatic login successful for ${clientCfg.name}"
+              else
+                echo "Automatic login failed for ${clientCfg.name}, continuing with service..."
+              fi
+              
+              # Wait for the service process
+              wait $SERVICE_PID
+            else
+              # No SetupKey, just run the service normally
+              echo "Debug: No SetupKey found in Nix configuration, running service normally"
+              exec ${clientCfg.package}/bin/netbird service run --config ${paths.configFile}
+            fi
+          '';
+          serviceConfig = {
+            EnvironmentVariables = getClientEnvVars clientCfg;
+            KeepAlive = true;
+            RunAtLoad = clientCfg.autoStart;
+            StandardOutPath = paths.logOut;
+            StandardErrorPath = paths.logErr;
+            GroupName = clientCfg.group;
+          };
+        })
+      )) cfg.clients);
+
+    # Ensure NetBird services are bootstrapped if missing (e.g., after manual bootout)
+    system.activationScripts.postActivation.text = lib.mkAfter (let
+      labelPrefix = config.launchd.labelPrefix;
+      enabledClients = lib.filterAttrs (n: t: t.enable) cfg.clients;
+      clientLabels = lib.mapAttrsToList (n: t: "${labelPrefix}.netbird-${t.name}") enabledClients;
+      defaultLabel = lib.optionals cfg.enable [ "${labelPrefix}.netbird" ];
+      allLabels = defaultLabel ++ clientLabels;
+      labelsString = lib.concatStringsSep " " allLabels;
+    in ''
+      for label in ${labelsString}; do
+        if ! /bin/launchctl print "system/''${label}" >/dev/null 2>&1; then
+          echo "bootstrapping netbird service ''${label}" >&2
+          /bin/launchctl bootstrap system "/Library/LaunchDaemons/''${label}.plist" || true
+          /bin/launchctl enable "system/''${label}" || true
+          /bin/launchctl kickstart -k "system/''${label}" || true
+        fi
+      done
+    '');
   };
 }


### PR DESCRIPTION
- Adds clients option for supporting multiple NetBird instances
- Generates isolated launchd daemons for each client
- Maintains backward compatibility with legacy enable option
- Adds comprehensive options: port, name, logLevel, interface, autoStart, openFirewall
- Implements a config management stategy that is able to merge the pre-configured Nix configuration with run-time configuration changes applied by the netbird services
- Implements automatic login with SetupKey

All of this aligns with the current NixOS module structure and options
