### PR TITLE
ci: bump macOS version (13 -> 14)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
   # TODO: Change them once the repository configuration is updated.
 
   test-stable:
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
     - name: Install Nix
@@ -29,7 +29,7 @@ jobs:
     - run: nix flake check --override-input nixpkgs nixpkgs/${{ env.NIXPKGS_BRANCH }}
 
   install-against-stable:
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v4
@@ -88,7 +88,7 @@ jobs:
           --override-input nixpkgs nixpkgs/${{ env.NIXPKGS_BRANCH }}
 
   install-flake:
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
The runners from macOS 14 on default to aarch64, so this will also transition us away from x86_64