### PR TITLE
Add system.defaults.finder.FXPreferredGroupBy

### DIFF
--- a/modules/system/defaults/finder.nix
+++ b/modules/system/defaults/finder.nix
@@ -50,6 +50,16 @@ in
       '';
     };
 
+    system.defaults.finder.FXPreferredGroupBy = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        Change the default "Group By" option.
+        The options are: "Name", "Kind", "Application", "Date Last Opened", "Date Added", "Date Modified", "Date Created", "Size", and "Finder Tags".
+        The default is unset ("None").
+      '';
+    };
+
     system.defaults.finder.FXPreferredViewStyle = mkOption {
       type = types.nullOr types.str;
       default = null;


### PR DESCRIPTION
This commit adds an option to set the default Finder view option "Group By".

<img width="282" height="673" alt="Screenshot 2025-08-26 at 23 37 11" src="https://github.com/user-attachments/assets/a869ca31-eaa0-4ed4-8817-feafbb14d57f" />
