### PR TITLE
`apply` should return `null` if the argument is not a list

### DIFF
--- a/modules/launchd/launchd.nix
+++ b/modules/launchd/launchd.nix
@@ -121,7 +121,17 @@ in
         key. Please note: many people are confused by this key. Please read `execvp(3)` very carefully!
       '';
       # TODO: Remove this some time after 25.11.
-      apply = map (value: lib.warnIf (lib.hasInfix "&amp;" value) "A value for `ProgramArguments` contains the literal string `&amp;`. This is no longer necessary and will lead to double-escaping, as nix-darwin now automatically escapes special characters." value);
+      apply =
+        val:
+        if (builtins.isNull val) then
+          val
+        else
+          (map (
+            item:
+            lib.warnIf (lib.hasInfix "&amp;" item)
+              "A value for `ProgramArguments` contains the literal string `&amp;`. This is no longer necessary and will lead to double-escaping, as nix-darwin now automatically escapes special characters."
+            item
+          ) val);
     };
 
     EnableGlobbing = mkOption {


### PR DESCRIPTION
Fixes https://github.com/nix-darwin/nix-darwin/issues/1578
