### PR TITLE
[25.05] github-runner: fix the nodeRuntimes option

### DIFF
--- a/modules/services/github-runner/service.nix
+++ b/modules/services/github-runner/service.nix
@@ -76,7 +76,7 @@ in
 
   config.launchd.daemons = flip mapAttrs' config.services.github-runners (name: cfg:
     let
-      package = cfg.package.override (old: optionalAttrs (hasAttr "nodeRuntimes" old) { inherit (cfg) nodeRuntimes; });
+      package = cfg.package.override { inherit (cfg) nodeRuntimes; };
       stateDir = mkStateDir cfg;
       logDir = mkLogDir cfg;
       workDir = mkWorkDir cfg;

--- a/tests/services-github-runners.nix
+++ b/tests/services-github-runners.nix
@@ -4,9 +4,6 @@
     enable = true;
     url = "https://github.com/nixos/nixpkgs";
     tokenFile = "/secret/path/to/a/github/token";
-    # We need an overridable derivation but cannot use the actual github-runner package
-    # since it still relies on Node.js 16 which is marked as insecure.
-    package = pkgs.hello;
   };
 
   test = ''


### PR DESCRIPTION
The conditional override was intended to be backwards-compatible with older runner packages without the `nodeRuntimes` argument. However, `override` doesn't yield default arguments, so the override was never applied.

This commit removes the conditional entirely since `nodeRuntimes` was added back in 24.05.

(cherry picked from commits f910ac37b62f28ef613b2947c27f34359ceb9f41 and 165ff3069d0f75961e8e3f51461a3ffc1458f453)

Backport of #1582.