### PR TITLE
[25.05] github-runner: add support for node24

### DIFF
--- a/modules/services/github-runner/options.nix
+++ b/modules/services/github-runner/options.nix
@@ -262,8 +262,8 @@ in
         };
 
         nodeRuntimes = mkOption {
-          type = with types; nonEmptyListOf (enum [ "node20" ]);
-          default = [ "node20" ];
+          type = with types; nonEmptyListOf (enum [ "node20" "node24" ]);
+          default = [ "node20" "node24" ];
           description = ''
             List of Node.js runtimes the runner should support.
           '';


### PR DESCRIPTION
Backport of https://github.com/nix-darwin/nix-darwin/pull/1573 to 25.05 that received the same GitHub runner package and NixOS module update.
