### PR TITLE
netbird: add support for multiple clients

### DIFF
--- a/modules/services/netbird.nix
+++ b/modules/services/netbird.nix
@@ -1,35 +1,185 @@
-{ config, lib, pkgs, ... }:
-with lib;
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
 let
+  inherit (lib)
+    attrValues
+    concatLists
+    escapeShellArgs
+    getExe
+    literalExpression
+    maintainers
+    mapAttrs'
+    mapAttrsToList
+    mkDefault
+    mkIf
+    mkMerge
+    mkOption
+    mkOptionDefault
+    mkPackageOption
+    nameValuePair
+    types
+    unique
+    ;
+
   cfg = config.services.netbird;
+  clientList = attrValues cfg.clients;
+  serviceNames = map (c: c.serviceName) clientList;
 in
 {
+  meta.maintainers = [ maintainers.siriobalmelli ];
+
   options.services.netbird = {
-    enable = mkEnableOption "Netbird daemon";
-    package = mkOption {
-      type = types.package;
-      default = pkgs.netbird;
-      defaultText = literalExpression "pkgs.netbird";
-      description = "The package to use for netbird";
-    };
-  };
-  config = mkIf cfg.enable {
-    environment.systemPackages = [ cfg.package ];
-    launchd.daemons.netbird = {
-      script = ''
-        mkdir -p /var/run/netbird /var/lib/netbird
-        exec ${cfg.package}/bin/netbird service run
-      '';
-      serviceConfig = {
-        EnvironmentVariables = {
-          NB_CONFIG = "/var/lib/netbird/config.json";
-          NB_LOG_FILE = "console";
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Enables backward-compatible NetBird client service.
+
+        This is strictly equivalent to:
+
+        ```nix
+        services.netbird.clients.default = {
+          name = "netbird";
+          interface = "utun100";
         };
-        KeepAlive = true;
-        RunAtLoad = true;
-        StandardOutPath = "/var/log/netbird.out.log";
-        StandardErrorPath = "/var/log/netbird.err.log";
-      };
+        ```
+      '';
+    };
+
+    package = mkPackageOption pkgs "netbird" { };
+
+    clients = mkOption {
+      type = types.attrsOf (
+        types.submodule (
+          { name, config, ... }:
+          let
+            client = config;
+          in
+          {
+            options = {
+              name = mkOption {
+                type = types.str;
+                default = name;
+                description = "Client/network name.";
+              };
+
+              interface = mkOption {
+                type = types.strMatching "utun[0-9]+";
+                description = "Network interface managed by this client (must match `utun[0-9]+`).";
+              };
+
+              serviceName = mkOption {
+                type = types.str;
+                default = if client.name != "netbird" then "netbird-${client.name}" else client.name;
+                description = "Launchd service name and directory basename.";
+              };
+
+              dir = {
+                runtime = mkOption {
+                  type = types.path;
+                  default = "/var/run/${client.serviceName}";
+                  description = "Per-client runtime directory.";
+                };
+                state = mkOption {
+                  type = types.path;
+                  default = "/var/lib/${client.serviceName}";
+                  description = "Per-client state/config directory.";
+                };
+              };
+
+              environment = mkOption {
+                type = types.attrsOf types.str;
+                default = { };
+                description = "Environment variables for the netbird daemon.";
+              };
+
+              wrapper = mkOption {
+                type = types.package;
+                internal = true;
+                default =
+                  let
+                    makeWrapperArgs = concatLists (
+                      mapAttrsToList (key: value: [
+                        "--set-default"
+                        key
+                        value
+                      ]) client.environment
+                    );
+                  in
+                  pkgs.stdenv.mkDerivation {
+                    name = "${cfg.package.name}-wrapper-${client.serviceName}";
+                    meta.mainProgram = client.serviceName;
+                    nativeBuildInputs = [ pkgs.makeWrapper ];
+                    buildCommand = ''
+                      mkdir -p "$out/bin"
+                      makeWrapper ${getExe cfg.package} "$out/bin/${client.serviceName}" \
+                        ${escapeShellArgs makeWrapperArgs}
+                    '';
+                  };
+              };
+            };
+
+            config.environment = {
+              NB_STATE_DIR = client.dir.state;
+              NB_CONFIG = "${client.dir.state}/config.json";
+              NB_DAEMON_ADDR = "unix://${client.dir.runtime}/sock";
+              NB_INTERFACE_NAME = client.interface;
+              NB_LOG_FILE = mkOptionDefault "console";
+              NB_SERVICE = client.serviceName;
+            };
+          }
+        )
+      );
+      default = { };
+      description = "Attribute set of NetBird client daemons.";
+      example = literalExpression ''
+        {
+          work = { interface = "utun100"; };
+          home = { interface = "utun101"; };
+        }
+      '';
     };
   };
+
+  config = mkMerge [
+    (mkIf cfg.enable {
+      services.netbird.clients.default = {
+        name = mkDefault "netbird";
+        interface = mkDefault "utun100";
+      };
+    })
+    {
+      assertions = [
+        {
+          assertion = serviceNames == unique serviceNames;
+          message = "services.netbird: all clients must have unique serviceName values.";
+        }
+      ];
+
+      environment.systemPackages = map (c: c.wrapper) clientList;
+
+      launchd.daemons = mapAttrs' (
+        _: client:
+        nameValuePair client.serviceName {
+          script = ''
+            install -d -m 0755 ${client.dir.runtime}
+            install -d -m 0700 ${client.dir.state}
+            exec ${cfg.package}/bin/netbird service run
+          '';
+          serviceConfig = {
+            EnvironmentVariables = client.environment;
+            KeepAlive = true;
+            RunAtLoad = true;
+            StandardOutPath = "/var/log/${client.serviceName}.out.log";
+            StandardErrorPath = "/var/log/${client.serviceName}.err.log";
+          };
+        }
+      ) cfg.clients;
+    }
+  ];
 }

--- a/release.nix
+++ b/release.nix
@@ -110,6 +110,7 @@ in {
   tests.services-dnsmasq = makeTest ./tests/services-dnsmasq.nix;
   tests.services-dnscrypt-proxy = makeTest ./tests/services-dnscrypt-proxy.nix;
   tests.services-eternal-terminal = makeTest ./tests/services-eternal-terminal.nix;
+  tests.services-netbird = makeTest ./tests/services-netbird.nix;
   tests.services-nix-gc = makeTest ./tests/services-nix-gc.nix;
   tests.services-nix-optimise = makeTest ./tests/services-nix-optimise.nix;
   tests.services-nextdns = makeTest ./tests/services-nextdns.nix;

--- a/release.nix
+++ b/release.nix
@@ -114,6 +114,7 @@ in {
   tests.services-dnsmasq = makeTest ./tests/services-dnsmasq.nix;
   tests.services-dnscrypt-proxy = makeTest ./tests/services-dnscrypt-proxy.nix;
   tests.services-eternal-terminal = makeTest ./tests/services-eternal-terminal.nix;
+  tests.services-netbird = makeTest ./tests/services-netbird.nix;
   tests.services-nix-gc = makeTest ./tests/services-nix-gc.nix;
   tests.services-nix-optimise = makeTest ./tests/services-nix-optimise.nix;
   tests.services-nextdns = makeTest ./tests/services-nextdns.nix;

--- a/tests/services-netbird.nix
+++ b/tests/services-netbird.nix
@@ -1,0 +1,33 @@
+{ config, pkgs, ... }:
+
+let
+  netbird = pkgs.runCommand "netbird-0.0.0" { meta.mainProgram = "netbird"; } ''
+    mkdir -p $out/bin
+    touch $out/bin/netbird
+    chmod +x $out/bin/netbird
+  '';
+in
+{
+  services.netbird = {
+    enable = true;
+    package = netbird;
+    clients.corp.interface = "utun101";
+  };
+
+  test = ''
+    echo >&2 "checking default netbird daemon in /Library/LaunchDaemons"
+    grep "org.nixos.netbird" ${config.out}/Library/LaunchDaemons/org.nixos.netbird.plist
+    grep "utun100" ${config.out}/Library/LaunchDaemons/org.nixos.netbird.plist
+    grep "/var/lib/netbird/config.json" ${config.out}/Library/LaunchDaemons/org.nixos.netbird.plist
+    grep "/var/log/netbird.out.log" ${config.out}/Library/LaunchDaemons/org.nixos.netbird.plist
+    grep "/var/log/netbird.err.log" ${config.out}/Library/LaunchDaemons/org.nixos.netbird.plist
+
+    echo >&2 "checking netbird-corp daemon in /Library/LaunchDaemons"
+    grep "org.nixos.netbird-corp" ${config.out}/Library/LaunchDaemons/org.nixos.netbird-corp.plist
+    grep "utun101" ${config.out}/Library/LaunchDaemons/org.nixos.netbird-corp.plist
+    grep "/var/lib/netbird-corp/config.json" ${config.out}/Library/LaunchDaemons/org.nixos.netbird-corp.plist
+    grep "unix:///var/run/netbird-corp/sock" ${config.out}/Library/LaunchDaemons/org.nixos.netbird-corp.plist
+    grep "/var/log/netbird-corp.out.log" ${config.out}/Library/LaunchDaemons/org.nixos.netbird-corp.plist
+    grep "/var/log/netbird-corp.err.log" ${config.out}/Library/LaunchDaemons/org.nixos.netbird-corp.plist
+  '';
+}


### PR DESCRIPTION
Allows multiple netbird instances using the 'clients' attribute.

Maintains backwards-compatibility using the 'default' client, following the same pattern as the nixos modules.

Combined with the upstream netbird PR https://github.com/netbirdio/netbird/pull/4633 this allows a nix-darwin host to participate in multiple netbird overlay networks at once, independently of each other.