### PR TITLE
services/wg-quick: use command instead of ProgramArguments

### DIFF
--- a/modules/services/wg-quick.nix
+++ b/modules/services/wg-quick.nix
@@ -186,6 +186,7 @@ let
 
   generateLaunchDaemonAttrs = name: interfaceOpt:
     nameValuePair "wg-quick-${name}" {
+      command = "${pkgs.wireguard-tools}/bin/wg-quick up ${name}";
       serviceConfig = {
         EnvironmentVariables = {
           PATH =
@@ -195,8 +196,6 @@ let
           NetworkState = true;
           SuccessfulExit = true;
         };
-        ProgramArguments =
-          [ "${pkgs.wireguard-tools}/bin/wg-quick" "up" "${name}" ];
         RunAtLoad = true;
         StandardErrorPath = "${cfg.logDir}/wg-quick-${name}.log";
         StandardOutPath = "${cfg.logDir}/wg-quick-${name}.log";


### PR DESCRIPTION
Using `command' automatically adds wait4path, which is needed to ensure that the service starts successfully on boot.