### PR TITLE
programs/nh: new module

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -113,6 +113,7 @@
   ./programs/gnupg.nix
   ./programs/man.nix
   ./programs/info
+  ./programs/nh.nix
   ./programs/nix-index
   ./programs/ssh.nix
   ./programs/tmux.nix

--- a/modules/programs/nh.nix
+++ b/modules/programs/nh.nix
@@ -1,0 +1,141 @@
+# Based off: https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/programs/nh.nix
+# When making changes please try to keep it in sync.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.nh;
+  launchdTypes = import ../launchd/types.nix { inherit config lib; };
+in
+
+{
+
+  meta.maintainers = [
+    lib.maintainers.rajanmaghera or "rajanmaghera"
+  ];
+
+  imports = [
+    (lib.mkRemovedOptionModule [
+      "programs"
+      "nh"
+      "clean"
+      "dates"
+    ] "Use `programs.nh.clean.interval` instead.")
+  ];
+
+  ###### interface
+
+  options = {
+
+    programs.nh = {
+      enable = lib.mkEnableOption "nh, yet another Nix CLI helper";
+
+      package = lib.mkPackageOption pkgs "nh" { };
+
+      flake = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          The string that will be used for the `NH_FLAKE` environment variable.
+
+          `NH_FLAKE` is used by nh as the default flake for performing actions, such as
+          `nh os switch`. This behaviour can be overriden per-command with environment
+          variables that will take priority.
+
+          - `NH_OS_FLAKE`: will take priority for `nh os` commands.
+          - `NH_HOME_FLAKE`: will take priority for `nh home` commands.
+          - `NH_DARWIN_FLAKE`: will take priority for `nh darwin` commands.
+
+          The formerly valid `FLAKE` is now deprecated by nh, and will cause hard errors
+          in future releases if `NH_FLAKE` is not set.
+        '';
+      };
+
+      clean = {
+        enable = lib.mkEnableOption "periodic garbage collection with nh clean all";
+
+        interval = lib.mkOption {
+          type = launchdTypes.StartCalendarInterval;
+          default = [
+            {
+              Weekday = 7;
+              Hour = 3;
+              Minute = 15;
+            }
+          ];
+          description = ''
+            The calendar interval at which the garbage collector will run.
+            See the {option}`serviceConfig.StartCalendarInterval` option of
+            the {option}`launchd` module for more info.
+          '';
+        };
+
+        extraArgs = lib.mkOption {
+          type = lib.types.singleLineStr;
+          default = "";
+          example = "--keep 5 --keep-since 3d";
+          description = ''
+            Options given to nh clean when the service is run automatically.
+
+            See `nh clean all --help` for more information.
+          '';
+        };
+      };
+    };
+  };
+
+  ###### implementation
+
+  config = {
+
+    warnings =
+      if (!(cfg.clean.enable -> !config.nix.gc.automatic)) then
+        [
+          "programs.nh.clean.enable and nix.gc.automatic are both enabled. Please use one or the other to avoid conflict."
+        ]
+      else
+        [ ];
+
+    assertions = [
+      # Not strictly required but probably a good assertion to have
+      {
+        assertion = cfg.clean.enable -> cfg.enable;
+        message = "programs.nh.clean.enable requires programs.nh.enable";
+      }
+
+      {
+        assertion = (cfg.flake != null) -> !(lib.hasSuffix ".nix" cfg.flake);
+        message = "nh.flake must be a directory, not a nix file";
+      }
+      {
+        assertion = cfg.clean.enable -> config.nix.enable;
+        message = "programs.nh.clean.enable requires nix.enable";
+      }
+    ];
+
+    environment = lib.mkIf cfg.enable {
+      systemPackages = [ cfg.package ];
+      variables = lib.mkIf (cfg.flake != null) {
+        NH_FLAKE = cfg.flake;
+      };
+    };
+
+    launchd.daemons.nh-clean = lib.mkIf cfg.clean.enable {
+      path = [ config.nix.package ];
+      command = "${lib.getExe cfg.package} clean all ${cfg.clean.extraArgs}";
+      serviceConfig = {
+        RunAtLoad = false;
+        StartCalendarInterval = cfg.clean.interval;
+        WorkingDirectory = "/var/root";
+        # cleanup jobs are low priority
+        LowPriorityIO = true;
+        LowPriorityBackgroundIO = true;
+        ProcessType = "Background";
+      };
+    };
+  };
+}

--- a/release.nix
+++ b/release.nix
@@ -94,6 +94,7 @@ in {
   tests.nix-enable = makeTest ./tests/nix-enable.nix;
   tests.nixpkgs-overlays = makeTest ./tests/nixpkgs-overlays.nix;
   tests.programs-gnupg = makeTest ./tests/programs-gnupg.nix;
+  tests.programs-nh = makeTest ./tests/programs-nh.nix;
   tests.programs-ssh = makeTest ./tests/programs-ssh.nix;
   tests.programs-tmux = makeTest ./tests/programs-tmux.nix;
   tests.programs-zsh = makeTest ./tests/programs-zsh.nix;

--- a/tests/programs-nh.nix
+++ b/tests/programs-nh.nix
@@ -1,0 +1,23 @@
+{ config, pkgs, ... }:
+
+let
+  nix = pkgs.runCommand "nix-2.2" { } "mkdir -p $out";
+  nh = pkgs.runCommand "nh" { } "mkdir -p $out";
+in
+
+{
+  programs.nh.enable = true;
+  programs.nh.package = nh;
+  programs.nh.clean.enable = true;
+  programs.nh.clean.extraArgs = "--keep 5 --keep-since 3d";
+  nix.package = nix;
+
+  test = ''
+    echo checking nh-clean service in /Library/LaunchDaemons >&2
+    grep "<string>${nix}/bin</string>" ${config.out}/Library/LaunchDaemons/org.nixos.nh-clean.plist
+    grep "<string>org.nixos.nh-clean</string>" ${config.out}/Library/LaunchDaemons/org.nixos.nh-clean.plist
+    grep "<string>/bin/wait4path /nix/store &amp;&amp; exec ${nh}/bin/nh clean all --keep 5 --keep-since 3d</string>" ${config.out}/Library/LaunchDaemons/org.nixos.nh-clean.plist
+
+    (! grep "<key>KeepAlive</key>" ${config.out}/Library/LaunchDaemons/org.nixos.nh-clean.plist)
+  '';
+}


### PR DESCRIPTION
Adds a new module `programs.nh` based on the NixOS equivalent. `programs.nh.clean` can be used instead of `nix.gc` as a periodic garbage collection sweep with more options.