### PR TITLE
netdata: set mainProgram for the test package

### DIFF
--- a/tests/services-netdata.nix
+++ b/tests/services-netdata.nix
@@ -3,7 +3,7 @@
 with lib;
 
 let
-  netdata = pkgs.runCommand "netdata-0.0.0" {} "mkdir $out";
+  netdata = pkgs.runCommand "netdata-0.0.0" { meta.mainProgram = "netdata"; } "mkdir $out";
 in
 {
   services.netdata = {


### PR DESCRIPTION
avoids the evaluation warning appearing in CI logs: "netdata-0.0.0" does not have the meta.mainProgram attribute.