### PR TITLE
mas: support declaring apps by bundle id

### DIFF
--- a/modules/homebrew.nix
+++ b/modules/homebrew.nix
@@ -868,12 +868,13 @@ in
     };
 
     masApps = mkOption {
-      type = types.attrsOf types.ints.positive;
+      type = types.attrsOf (types.either types.ints.positive types.str);
       default = { };
       example = literalExpression ''
         {
           "1Password for Safari" = 1569813296;
           Xcode = 497799835;
+          Fantastical = "com.flexibits.fantastical2.mac";
         }
       '';
       description = ''

--- a/tests/homebrew.nix
+++ b/tests/homebrew.nix
@@ -75,6 +75,7 @@ in
   homebrew.masApps = {
     "1Password for Safari" = 1569813296;
     Xcode = 497799835;
+    Fantastical = "com.flexibits.fantastical2.mac";
   };
 
   homebrew.vscode = [


### PR DESCRIPTION
Adds support for declaring Mac App Store Apps using Bundle Identifiers in addition to ADAM IDs, supported by [mas](https://github.com/mas-cli/mas) for [nearly a year](https://github.com/mas-cli/mas/pull/953)