### PR TITLE
nixpkgs: avoid evaluating inapplicable system option

### DIFF
--- a/modules/nix/nixpkgs.nix
+++ b/modules/nix/nixpkgs.nix
@@ -293,11 +293,13 @@ in
     assertions = [
       (
         let
+          darwinExpectedSystem = if hasHostPlatform then cfg.hostPlatform.system else cfg.system;
+          darwinOption = if hasHostPlatform then "nixpkgs.hostPlatform" else "nixpkgs.system";
           pkgsSystem = finalPkgs.stdenv.targetPlatform.system;
         in
         {
-          assertion = cfg.constructedByUs -> !hasPlatform -> cfg.system == pkgsSystem;
-          message = "The nix-darwin nixpkgs.pkgs option was set to a Nixpkgs invocation that compiles to target system ${pkgsSystem} but nix-darwin was configured for system ${config.nixpkgs.system} via nix-darwin option nixpkgs.system. The nix-darwin system settings must match the Nixpkgs target system.";
+          assertion = cfg.constructedByUs -> !hasPlatform -> darwinExpectedSystem == pkgsSystem;
+          message = "The nix-darwin nixpkgs.pkgs option was set to a Nixpkgs invocation that compiles to target system ${pkgsSystem} but nix-darwin was configured for system ${darwinExpectedSystem} via nix-darwin option ${darwinOption}. The nix-darwin system settings must match the Nixpkgs target system.";
         }
       )
       {

--- a/release.nix
+++ b/release.nix
@@ -79,6 +79,7 @@ in {
   examples.simple = makeSystem ./modules/examples/simple.nix;
 
   tests.activation-scripts = makeTest ./tests/activation-scripts.nix;
+  tests.assertion-messages = makeTest ./tests/assertion-messages.nix;
   tests.autossh = makeTest ./tests/autossh.nix;
   tests.environment-path = makeTest ./tests/environment-path.nix;
   tests.environment-terminfo = makeTest ./tests/environment-terminfo.nix;

--- a/tests/assertion-messages.nix
+++ b/tests/assertion-messages.nix
@@ -1,0 +1,25 @@
+{ lib, pkgs, ... }:
+
+let
+  configuration = import ../eval-config.nix {
+    inherit lib;
+    modules = [
+      {
+        nixpkgs.source = pkgs.path;
+        nixpkgs.hostPlatform = pkgs.stdenv.hostPlatform;
+        system.stateVersion = 7;
+        system.primaryUser = "test";
+        users.knownUsers = [ "test" ];
+        users.users.test = {
+          home = "/Users/test";
+          uid = 501;
+        };
+      }
+    ];
+  };
+in
+{
+  test = builtins.deepSeq configuration.config.assertions ''
+    true
+  '';
+}


### PR DESCRIPTION
Right now I can't eval my config assertions; this should fix it.
