### PR TITLE
mas: support declaring apps by bundle id and migrate list parsing to JSON

### DIFF
--- a/modules/programs/mas.nix
+++ b/modules/programs/mas.nix
@@ -27,8 +27,8 @@ let
 
   apps = mapAttrsToList (name: id: { inherit name id; }) cfg.packages;
 
-  desiredIds = map (app: toString app.id) apps;
-  homebrewIds = map toString (attrValues config.homebrew.masApps);
+  desiredIds = map (app: escapeShellArg app.id) apps;
+  homebrewIds = map (id: escapeShellArg id) (attrValues config.homebrew.masApps);
 
   hasWork = cfg.update || cfg.packages != { } || cfg.cleanup || homebrewIds != [ ];
 
@@ -46,49 +46,59 @@ let
         }
 
         listStatus=0
+        listErrFile=$(mktemp)
         listOutput=$(
-          runAsUser ${getExe cfg.package} list 2>&1
+          runAsUser ${getExe cfg.package} list --json 2>"$listErrFile"
         ) || listStatus=$?
+        listErrors=$(<"$listErrFile")
+        rm -f "$listErrFile"
 
         if (( listStatus != 0 )); then
           echo >&2 "warning: mas list failed (exit ''${listStatus}):"
-          echo >&2 "''${listOutput}"
-          if echo "''${listOutput}" | grep -qi "not signed in"; then
+          echo >&2 "''${listErrors}"
+          if echo "''${listErrors}" | grep -qi "not signed in"; then
             echo >&2 "login required; skipping App Store installs/updates/cleanup"
             exit 0
           fi
         fi
 
-        # Only emit cleanup-only shell variables when cleanup is enabled; otherwise shellcheck
-        # treats them as unused and fails the activation script build.
-        installedIds=()
-        ${if cfg.cleanup then
-          ''
-            # Parse mas list output: "ID  AppName  (version)"
-            declare -A installedApps
-            while IFS= read -r line; do
-              [[ -z "$line" ]] && continue
-              line="''${line#"''${line%%[![:space:]]*}"}"
-              id="''${line%% *}"
-              rest="''${line#"$id"}"
-              rest="''${rest#"''${rest%%[![:space:]]*}"}"
+        installedAdamIds=()
+        installedBundleIds=()
+        ${optionalString cfg.cleanup ''
+          installedNames=()
+        ''}
+        while IFS=$'\t' read -r adamId bundleId${optionalString cfg.cleanup " name"}; do
+          [[ -z "$adamId" && -z "$bundleId" ]] && continue
+          installedAdamIds+=( "$adamId" )
+          installedBundleIds+=( "$bundleId" )
+          ${optionalString cfg.cleanup ''
+            installedNames+=( "$name" )
+          ''}
+        done < <(
+          printf '%s' "$listOutput" | sed 's/}{/}\n{/g' |
+            ${getExe pkgs.jq} --raw-output -R \
+              'fromjson? | select(type == "object") | [(.adamID // "" | tostring), .bundleID // ""${if cfg.cleanup then ", .name // \"\"" else ""}] | @tsv'
+        )
+
+        if (( ''${#installedAdamIds[@]} == 0 )) && [[ -n "$listOutput" ]]; then
+          while IFS= read -r line; do
+            [[ -z "$line" ]] && continue
+            line="''${line#"''${line%%[![:space:]]*}"}"
+            adamId="''${line%% *}"
+            rest="''${line#"$adamId"}"
+            rest="''${rest#"''${rest%%[![:space:]]*}"}"
+            ${optionalString cfg.cleanup ''
               name="''${rest% (*}"
               name="''${name%"''${name##*[![:space:]]}"}"
-              [[ -n "$id" ]] && {
-                installedIds+=( "$id" )
-                installedApps["$id"]="$name"
-              }
-            done <<<"$listOutput"
-          ''
-        else
-          ''
-            while IFS= read -r line; do
-              [[ -z "$line" ]] && continue
-              line="''${line#"''${line%%[![:space:]]*}"}"
-              id="''${line%% *}"
-              [[ -n "$id" ]] && installedIds+=( "$id" )
-            done <<<"$listOutput"
-          ''}
+            ''}
+            [[ -n "$adamId" ]] || continue
+            installedAdamIds+=( "$adamId" )
+            installedBundleIds+=( "" )
+            ${optionalString cfg.cleanup ''
+              installedNames+=( "$name" )
+            ''}
+          done <<<"$listOutput"
+        fi
 
         ${optionalString cfg.update ''
           runAsUser ${getExe cfg.package} update || true
@@ -100,8 +110,10 @@ let
 
         is_installed() {
           local needle=$1
-          for id in "''${installedIds[@]}"; do
-            if [[ "$id" == "$needle" ]]; then
+          local i
+          for (( i=0; i<''${#installedAdamIds[@]}; i++ )); do
+            if [[ "''${installedAdamIds[$i]}" == "$needle" ||
+                  "''${installedBundleIds[$i]}" == "$needle" ]]; then
               return 0
             fi
           done
@@ -113,7 +125,18 @@ let
             if is_installed "$appId"; then
               continue
             fi
-            runAsUser ${getExe cfg.package} install "$appId" || true
+            installStatus=0
+            installOutput=$(
+              runAsUser ${getExe cfg.package} install "$appId" 2>&1
+            ) || installStatus=$?
+            if [[ "$installOutput" =~ Warning:\ Already\ (installed|got) ]]; then
+              continue
+            fi
+            if [[ -n "$installOutput" ]]; then
+              echo >&2 "$installOutput"
+            elif (( installStatus != 0 )); then
+              echo >&2 "warning: mas install $appId failed (exit ''${installStatus})"
+            fi
           done
         ''}
 
@@ -124,17 +147,21 @@ let
 
           keepIds=( "''${desiredIds[@]}" "''${homebrewIds[@]}" )
 
-          for installedId in "''${installedIds[@]}"; do
+          for (( i=0; i<''${#installedAdamIds[@]}; i++ )); do
+            adamId="''${installedAdamIds[$i]}"
+            bundleId="''${installedBundleIds[$i]}"
             keep=false
             for keepId in "''${keepIds[@]}"; do
-              if [[ "$installedId" == "$keepId" ]]; then
+              if [[ "$adamId" == "$keepId" || "$bundleId" == "$keepId" ]]; then
                 keep=true
                 break
               fi
             done
 
             if ! $keep; then
-              appName="''${installedApps[$installedId]:-$installedId}"
+              installedId="$adamId"
+              [[ -n "$installedId" ]] || installedId="$bundleId"
+              appName="''${installedNames[$i]:-$installedId}"
               echo >&2 "removing $appName from App Store"
               runAsUser ${getExe cfg.package} uninstall "$installedId" || true
             fi
@@ -161,17 +188,18 @@ in
     package = mkPackageOption pkgs "mas" { };
 
     packages = mkOption {
-      type = types.attrsOf types.ints.positive;
+      type = types.attrsOf (types.either types.ints.positive types.str);
       default = { };
       example = literalExpression ''
         {
           Xcode = 497799835;
           "1Password for Safari" = 1569813296;
+          Keynote = "com.apple.iWork.Keynote";
         }
       '';
       description = ''
         Applications to install from the Mac App Store. Attribute names are only for readability;
-        values must be the numeric identifiers used by {command}`mas`.
+        values must be the numeric or bundle identifiers used by {command}`mas`.
       '';
     };
 

--- a/tests/programs-mas-no-cleanup.nix
+++ b/tests/programs-mas-no-cleanup.nix
@@ -46,9 +46,20 @@ in
     grep 'mas install \"$appId\"' ${config.out}/activate
     grep 'mas update' ${config.out}/activate
 
+    echo "checking mas parses JSON output" >&2
+    grep 'mas list --json' ${config.out}/activate
+    grep 'fromjson?' ${config.out}/activate
+    grep '\.adamID' ${config.out}/activate
+    grep '\.bundleID' ${config.out}/activate
+
+    if grep 'list --json 2>&1' ${config.out}/activate; then
+      echo "mas list stderr must not be merged into JSON output" >&2
+      exit 1
+    fi
+
     echo "checking cleanup-only variables are omitted" >&2
-    if grep 'declare -A installedApps' ${config.out}/activate; then
-      echo "unexpected installedApps declaration when cleanup is disabled" >&2
+    if grep 'installedNames=' ${config.out}/activate; then
+      echo "unexpected installedNames declaration when cleanup is disabled" >&2
       exit 1
     fi
 

--- a/tests/programs-mas.nix
+++ b/tests/programs-mas.nix
@@ -30,6 +30,7 @@ in
     cleanup = true;
     packages = {
       "1Password for Safari" = 1569813296;
+      Keynote = "com.apple.iWork.Keynote";
       Xcode = 497799835;
     };
   };
@@ -48,6 +49,7 @@ in
     echo "checking mas desired ids are present" >&2
     grep 'desiredIds=(' ${config.out}/activate
     grep '1569813296' ${config.out}/activate
+    grep 'com.apple.iWork.Keynote' ${config.out}/activate
     grep '497799835' ${config.out}/activate
 
     echo "checking mas install loop exists" >&2
@@ -56,9 +58,17 @@ in
     echo "checking mas update is triggered" >&2
     grep 'mas update' ${config.out}/activate
 
-    echo "checking mas parses installedApps from mas list" >&2
-    grep 'declare -A installedApps' ${config.out}/activate
-    grep 'installedApps\[' ${config.out}/activate
+    echo "checking mas parses JSON output" >&2
+    grep 'mas list --json' ${config.out}/activate
+    grep 'fromjson?' ${config.out}/activate
+    grep '\.adamID' ${config.out}/activate
+    grep '\.bundleID' ${config.out}/activate
+    grep '\.name' ${config.out}/activate
+
+    if grep 'list --json 2>&1' ${config.out}/activate; then
+      echo "mas list stderr must not be merged into JSON output" >&2
+      exit 1
+    fi
 
     echo "checking mas cleanup log and uninstall" >&2
     grep 'removing .* from App Store' ${config.out}/activate


### PR DESCRIPTION
support declaring apps by bundle id (similar to https://github.com/nix-darwin/nix-darwin/pull/1846) and migrate list parsing to use the new --json output [mas@v7.0.0](https://github.com/mas-cli/mas/releases/tag/v7.0.0)