### PR TITLE
services/xquartz: init

### DIFF
--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -102,6 +102,7 @@
   ./services/tailscale.nix
   ./services/trezord.nix
   ./services/wg-quick.nix
+  ./services/xquartz.nix
   ./services/yabai
   ./services/nextdns
   ./services/jankyborders

--- a/modules/services/xquartz.nix
+++ b/modules/services/xquartz.nix
@@ -1,0 +1,60 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.xquartz;
+in
+{
+  options.services.xquartz = {
+    enable = lib.mkEnableOption "XQuartz";
+
+    package = lib.mkPackageOption pkgs "xquartz" { };
+
+    configureSsh = lib.mkEnableOption "OpenSSH client integration for X11 forwarding";
+  };
+
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        environment.systemPackages = [ cfg.package ];
+
+        launchd.agents.xquartz-startx = {
+          command = lib.escapeShellArgs [
+            "${cfg.package}/libexec/launchd_startx"
+            "${cfg.package}/bin/startx"
+            "--"
+            "${cfg.package}/bin/Xquartz"
+          ];
+          serviceConfig = {
+            Label = "org.nixos.xquartz.startx";
+            Sockets."org.nixos.xquartz:0".SecureSocketWithKey = "DISPLAY";
+            # xinit uses vproc_transaction_begin while the X11 session runs.
+            EnableTransactions = true;
+          };
+        };
+
+        launchd.daemons.xquartz-privileged-startx = {
+          command = lib.escapeShellArgs [
+            "${cfg.package}/libexec/privileged_startx"
+            "-d"
+            "${cfg.package}/etc/X11/xinit/privileged_startx.d"
+          ];
+          serviceConfig = {
+            Label = "org.nixos.xquartz.privileged_startx";
+            MachServices."org.nixos.xquartz.privileged_startx" = true;
+          };
+        };
+      }
+
+      (lib.mkIf cfg.configureSsh {
+        programs.ssh.extraConfig = lib.mkAfter ''
+          XAuthLocation ${lib.getExe pkgs.xauth}
+        '';
+      })
+    ]
+  );
+}

--- a/release.nix
+++ b/release.nix
@@ -128,6 +128,7 @@ in {
   tests.services-spotifyd = makeTest ./tests/services-spotifyd.nix;
   tests.services-synapse-bt = makeTest ./tests/services-synapse-bt.nix;
   tests.services-synergy = makeTest ./tests/services-synergy.nix;
+  tests.services-xquartz = makeTest ./tests/services-xquartz.nix;
   tests.services-yabai = makeTest ./tests/services-yabai.nix;
   tests.services-jankyborders = makeTest ./tests/services-jankyborders.nix;
   tests.system-defaults-write = makeTest ./tests/system-defaults-write.nix;

--- a/tests/services-xquartz.nix
+++ b/tests/services-xquartz.nix
@@ -1,0 +1,45 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  xquartz = pkgs.runCommand "xquartz-0.0.0" { } ''
+    mkdir -p $out/bin $out/libexec $out/etc/X11/xinit/privileged_startx.d
+    touch $out/bin/Xquartz $out/bin/startx
+    touch $out/libexec/launchd_startx $out/libexec/privileged_startx
+  '';
+  agent = "${config.out}/Library/LaunchAgents/org.nixos.xquartz.startx.plist";
+  daemon = "${config.out}/Library/LaunchDaemons/org.nixos.xquartz.privileged_startx.plist";
+in
+{
+  services.xquartz = {
+    enable = true;
+    package = xquartz;
+    configureSsh = true;
+  };
+
+  test = ''
+    echo >&2 "checking XQuartz package in /sw/bin"
+    test "$(readlink -f ${config.out}/sw/bin/Xquartz)" = "${xquartz}/bin/Xquartz"
+
+    echo >&2 "checking XQuartz LaunchAgent"
+    grep -F '${xquartz}/libexec/launchd_startx ${xquartz}/bin/startx -- ${xquartz}/bin/Xquartz' ${agent}
+    grep -F '<key>SecureSocketWithKey</key>' ${agent}
+    grep -F '<string>DISPLAY</string>' ${agent}
+    test ! -e ${config.out}/user/Library/LaunchAgents/org.nixos.xquartz.startx.plist
+
+    echo >&2 "checking XQuartz privileged LaunchDaemon"
+    grep -F '${xquartz}/libexec/privileged_startx -d ${xquartz}/etc/X11/xinit/privileged_startx.d' ${daemon}
+    grep -F '<key>MachServices</key>' ${daemon}
+    grep -F '<key>org.nixos.xquartz.privileged_startx</key>' ${daemon}
+
+    echo >&2 "checking system-wide LaunchAgent activation"
+    grep -F "launchctl load -w '/Library/LaunchAgents/org.nixos.xquartz.startx.plist'" ${config.out}/activate
+
+    echo >&2 "checking OpenSSH XAuthLocation"
+    grep -F 'XAuthLocation ${lib.getExe pkgs.xauth}' ${config.out}/etc/ssh/ssh_config.d/100-nix-darwin.conf
+  '';
+}


### PR DESCRIPTION
Thanks to @Feyorsh for initial inspiration at:
https://github.com/nix-darwin/nix-darwin/pull/1542

This module does *not* rely on plists from xquartz package but defines
services natively. Comparing to upstream packaged plists, I removed a
lot of unnecessary / obsolete / unused attributes and only left those
necessary for the operation of the service.
